### PR TITLE
8226810: Failed to launch JVM because of NullPointerException occured on System.props

### DIFF
--- a/make/data/charsetmapping/stdcs-windows
+++ b/make/data/charsetmapping/stdcs-windows
@@ -2,6 +2,7 @@
 #   generate these charsets into sun.nio.cs
 #
 GBK
+GB18030
 Johab
 MS1255
 MS1256


### PR DESCRIPTION
This simple backport enables the GB18030 charset to be built into java.base on Windows.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8226810](https://bugs.openjdk.java.net/browse/JDK-8226810): Failed to launch JVM because of NullPointerException occured on System.props


### Download
`$ git fetch https://git.openjdk.java.net/jdk16u pull/4/head:pull/4`
`$ git checkout pull/4`
