### PR TITLE
8259048: (tz) Upgrade time-zone data to tzdata2020f

### DIFF
--- a/make/data/tzdata/VERSION
+++ b/make/data/tzdata/VERSION
@@ -21,4 +21,4 @@
 # or visit www.oracle.com if you need additional information or have any
 # questions.
 #
-tzdata2020d
+tzdata2020f

--- a/make/data/tzdata/africa
+++ b/make/data/tzdata/africa
@@ -409,36 +409,87 @@ Zone	Africa/Cairo	2:05:09 -	LMT	1900 Oct
 
 # Ghana
 
-# From Paul Eggert (2018-01-30):
-# Whitman says DST was observed from 1931 to "the present";
-# Shanks & Pottenger say 1936 to 1942 with 20 minutes of DST,
-# with transitions on 09-01 and 12-31 at 00:00.
-# Page 33 of Parish GCB, Colonial Reports - Annual. No. 1066. Gold
-# Coast. Report for 1919. (March 1921), OCLC 784024077
-# http://libsysdigi.library.illinois.edu/ilharvest/africana/books2011-05/5530214/5530214_1919/5530214_1919_opt.pdf
-# lists the Determination of the Time Ordinance, 1919, No. 18,
-# "to advance the time observed locally by the space of twenty minutes
-# during the last four months of each year; the object in view being
-# to extend during those months the period of daylight-time available
-# for evening recreation after office hours."
-# Vanessa Ogle, The Global Transformation of Time, 1870-1950 (2015), p 33,
-# writes "In 1919, the Gold Coast (Ghana as of 1957) made Greenwich
-# time its legal time and simultaneously legalized a summer time of
-# UTC - 00:20 minutes from March to October."; a footnote lists
-# the ordinance as being dated 1919-11-24.
-# The Crown Colonist, Volume 12 (1942), p 176, says "the Government
-# intend advancing Gold Coast time half an hour ahead of G.M.T.
-# The actual date of the alteration has not yet been announced."
-# These sources are incomplete and contradictory.  Possibly what is
-# now Ghana observed different DST regimes in different years.  For
-# lack of better info, use Shanks except treat the minus sign as a
-# typo, and assume DST started in 1920 not 1936.
+# From P Chan (2020-11-20):
+# Interpretation Amendment Ordinance, 1915 (No.24 of 1915) [1915-11-02]
+# Ordinances of the Gold Coast, Ashanti, Northern Territories 1915, p 69-71
+# https://books.google.com/books?id=ErA-AQAAIAAJ&pg=PA70
+# This Ordinance added "'Time' shall mean Greenwich Mean Time" to the
+# Interpretation Ordinance, 1876.
+#
+# Determination of the Time Ordinance, 1919 (No. 18 of 1919) [1919-11-24]
+# Ordinances of the Gold Coast, Ashanti, Northern Territories 1919, p 75-76
+# https://books.google.com/books?id=MbA-AQAAIAAJ&pg=PA75
+# This Ordinance removed the previous definition of time and introduced DST.
+#
+# Time Determination Ordinance (Cap. 214)
+# The Laws of the Gold Coast (including Togoland Under British Mandate)
+# Vol. II (1937), p 2328
+# https://books.google.com/books?id=Z7M-AQAAIAAJ&pg=PA2328
+# Revised edition of the 1919 Ordinance.
+#
+# Time Determination (Amendment) Ordinance, 1940 (No. 9 of 1940) [1940-04-06]
+# Annual Volume of the Laws of the Gold Coast:
+# Containing All Legislation Enacted During Year 1940, p 22
+# https://books.google.com/books?id=1ao-AQAAIAAJ&pg=PA22
+# This Ordinance changed the forward transition from September to May.
+#
+# Defence (Time Determination Ordinance Amendment) Regulations, 1942
+# (Regulations No. 6 of 1942) [1942-01-31, commenced on 1942-02-08]
+# Annual Volume of the Laws of the Gold Coast:
+# Containing All Legislation Enacted During Year 1942, p 48
+# https://books.google.com/books?id=Das-AQAAIAAJ&pg=PA48
+# These regulations advanced the [standard] time by thirty minutes.
+#
+# Defence (Time Determination Ordinance Amendment (No.2)) Regulations,
+# 1942 (Regulations No. 28 of 1942) [1942-04-25]
+# Annual Volume of the Laws of the Gold Coast:
+# Containing All Legislation Enacted During Year 1942, p 87
+# https://books.google.com/books?id=Das-AQAAIAAJ&pg=PA87
+# These regulations abolished DST and changed the time to GMT+0:30.
+#
+# Defence (Revocation) (No.4) Regulations, 1945 (Regulations No. 45 of
+# 1945) [1945-10-24, commenced on 1946-01-06]
+# Annual Volume of the Laws of the Gold Coast:
+# Containing All Legislation Enacted During Year 1945, p 256
+# https://books.google.com/books?id=9as-AQAAIAAJ&pg=PA256
+# These regulations revoked the previous two sets of Regulations.
+#
+# Time Determination (Amendment) Ordinance, 1945 (No. 18 of 1945) [1946-01-06]
+# Annual Volume of the Laws of the Gold Coast:
+# Containing All Legislation Enacted During Year 1945, p 69
+# https://books.google.com/books?id=9as-AQAAIAAJ&pg=PA69
+# This Ordinance abolished DST.
+#
+# Time Determination (Amendment) Ordinance, 1950 (No. 26 of 1950) [1950-07-22]
+# Annual Volume of the Laws of the Gold Coast:
+# Containing All Legislation Enacted During Year 1950, p 35
+# https://books.google.com/books?id=e60-AQAAIAAJ&pg=PA35
+# This Ordinance restored DST but with thirty minutes offset.
+#
+# Time Determination Ordinance (Cap. 264)
+# The Laws of the Gold Coast, Vol. V (1954), p 380
+# https://books.google.com/books?id=Mqc-AQAAIAAJ&pg=PA380
+# Revised edition of the Time Determination Ordinance.
+#
+# Time Determination (Amendment) Ordinance, 1956 (No. 21 of 1956) [1956-08-29]
+# Annual Volume of the Ordinances of the Gold Coast Enacted During the
+# Year 1956, p 83
+# https://books.google.com/books?id=VLE-AQAAIAAJ&pg=PA83
+# This Ordinance abolished DST.
+
 # Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
-Rule	Ghana	1920	1942	-	Sep	 1	0:00	0:20	-
-Rule	Ghana	1920	1942	-	Dec	31	0:00	0	-
+Rule	Ghana	1919	only	-	Nov	24	0:00	0:20	+0020
+Rule	Ghana	1920	1942	-	Jan	 1	2:00	0	GMT
+Rule	Ghana	1920	1939	-	Sep	 1	2:00	0:20	+0020
+Rule	Ghana	1940	1941	-	May	 1	2:00	0:20	+0020
+Rule	Ghana	1950	1955	-	Sep	 1	2:00	0:30	+0030
+Rule	Ghana	1951	1956	-	Jan	 1	2:00	0	GMT
+
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
-Zone	Africa/Accra	-0:00:52 -	LMT	1918
-			 0:00	Ghana	GMT/+0020
+Zone	Africa/Accra	-0:00:52 -	LMT	1915 Nov  2
+			 0:00	Ghana	%s	1942 Feb  8
+			 0:30	-	+0030	1946 Jan  6
+			 0:00	Ghana	%s
 
 # Guinea
 # See Africa/Abidjan.
@@ -456,11 +507,54 @@ Zone	Africa/Bissau	-1:02:20 -	LMT	1912 Jan  1  1:00u
 			 0:00	-	GMT
 
 # Kenya
+
+# From P Chan (2020-10-24):
+#
+# The standard time of GMT+2:30 was adopted in the East Africa Protectorate....
+# [The Official Gazette, 1908-05-01, p 274]
+# https://books.google.com/books?id=e-cAC-sjPSEC&pg=PA274
+#
+# At midnight on 30 June 1928 the clocks throughout Kenya was put forward
+# half an hour by the Alteration of Time Ordinance, 1928.
+# https://gazettes.africa/archive/ke/1928/ke-government-gazette-dated-1928-05-11-no-28.pdf
+# [Ordinance No. 11 of 1928, The Offical Gazette, 1928-06-26, p 813]
+# https://books.google.com/books?id=2S0S6os32ZUC&pg=PA813
+#
+# The 1928 ordinance was repealed by the Alteration of Time (repeal) Ordinance,
+# 1929 and the time was restored to GMT+2:30 at midnight on 4 January 1930.
+# [Ordinance No. 97 of 1929, The Official Gazette, 1929-12-31, p 2701]
+# https://books.google.com/books?id=_g18jIZQlwwC&pg=PA2701
+#
+# The Alteration of Time Ordinance, 1936 changed the time to GMT+2:45
+# and repealed the previous ordinance at midnight on 31 December 1936.
+# [The Official Gazette, 1936-07-21, p 705]
+# https://books.google.com/books?id=K7j41z0aC5wC&pg=PA705
+#
+# The Defence (Amendment of Laws No. 120) Regulations changed the time
+# to GMT+3 at midnight on 31 July 1942.
+# [Kenya Official Gazette Supplement No. 32, 1942-07-21, p 331]
+# https://books.google.com/books?hl=zh-TW&id=c_E-AQAAIAAJ&pg=PA331
+# The provision of the 1936 ordinance was not repealed and was later
+# incorporated in the Interpretation and General Clauses Ordinance in 1948.
+# Although it was overridden by the 1942 regulations.
+# [The Laws of Kenya in force on 1948-09-21, Title I, Chapter 1, 31]
+# https://dds.crl.edu/item/217517 (p.101)
+# In 1950 the Interpretation and General Clauses Ordinance was amended to adopt
+# GMT+3 permanently as the 1942 regulations were due to expire on 10 December.
+# https://books.google.com/books?id=jvR8mUDAwR0C&pg=PA787
+# [Ordinance No. 44 of 1950, Kenya Ordinances 1950, Vol. XXIX, p 294]
+# https://books.google.com/books?id=-_dQAQAAMAAJ&pg=PA294
+
+# From Paul Eggert (2020-10-24):
+# The 1908-05-01 announcement does not give an effective date,
+# so just say "1908 May".
+
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
-Zone	Africa/Nairobi	2:27:16	-	LMT	1928 Jul
-			3:00	-	EAT	1930
-			2:30	-	+0230	1940
-			2:45	-	+0245	1960
+Zone	Africa/Nairobi	2:27:16	-	LMT	1908 May
+			2:30	-	+0230	1928 Jun 30 24:00
+			3:00	-	EAT	1930 Jan  4 24:00
+			2:30	-	+0230	1936 Dec 31 24:00
+			2:45	-	+0245	1942 Jul 31 24:00
 			3:00	-	EAT
 Link Africa/Nairobi Africa/Addis_Ababa	 # Ethiopia
 Link Africa/Nairobi Africa/Asmara	 # Eritrea
@@ -1247,8 +1341,69 @@ Zone	Africa/Windhoek	1:08:24 -	LMT	1892 Feb 8
 # See Africa/Lagos.
 
 # Nigeria
+
+# From P Chan (2020-12-03):
+# GMT was adopted as the standard time of Lagos on 1905-07-01.
+# Lagos Weekly Record, 1905-06-24, p 3
+# http://ddsnext.crl.edu/titles/31558#?c=0&m=668&s=0&cv=2&r=0&xywh=1446%2C5221%2C1931%2C1235
+# says "It is officially notified that on and after the 1st of July 1905
+# Greenwich Mean Solar Time will be adopted thought the Colony and
+# Protectorate, and that it will be necessary to put all clocks 13 minutes and
+# 35 seconds back, recording local mean time."
+#
+# It seemed that Lagos returned to LMT on 1908-07-01.
+# [The Lagos Standard], 1908-07-01, p 5
+# http://ddsnext.crl.edu/titles/31556#?c=0&m=78&s=0&cv=4&r=0&xywh=-92%2C3590%2C3944%2C2523
+# says "Scarcely have the people become accustomed to this new time, when
+# another official notice has now appeared announcing that from and after the
+# 1st July next, return will be made to local mean time."
+#
+# From P Chan (2020-11-27):
+# On 1914-01-01, standard time of GMT+0:30 was adopted for the unified Nigeria.
+# Colonial Reports - Annual. No. 878. Nigeria. Report for 1914. (April 1916),
+# p 27
+# https://libsysdigi.library.illinois.edu/ilharvest/Africana/Books2011-05/3064634/3064634_1914/3064634_1914_opt.pdf#page=27
+# "On January 1st [1914], a universal standard time for Nigeria was adopted,
+# viz., half an hour fast on Greenwich mean time, corresponding to the meridian
+# 7 [degrees] 30' E. long."
+# Lloyd's Register of Shipping (1915) says "Hitherto the time observed in Lagos
+# was the local mean time. On 1st January, 1914, standard time for the whole of
+# Nigeria was introduced ... Lagos time has been advanced about 16 minutes
+# accordingly."
+#
+# In 1919, standard time was changed to GMT+1.
+# Interpretation Ordinance (Cap 2)
+# The Laws of Nigeria, Containing the Ordinances of Nigeria, in Force on the
+# 1st Day of January, 1923, Vol.I [p 16]
+# https://books.google.com/books?id=BOMrAQAAMAAJ&pg=PA16
+# "The expression 'Standard time' means standard time as used in Nigeria:
+# namely, 60 minutes in advance of Greenwich mean time.  (As amended by 18 of
+# 1919, s. 2.)"
+# From Tim Parenti (2020-12-10):
+# The Lagos Weekly Record, 1919-09-20, p 3 details discussion on the first
+# reading of this Bill by the Legislative Council of the Colony of Nigeria on
+# Thursday 1919-08-28:
+# http://ddsnext.crl.edu/titles/31558?terms&item_id=303484#?m=1118&c=1&s=0&cv=2&r=0&xywh=1261%2C3408%2C2994%2C1915
+# "The proposal is that the Globe should be divided into twelve zones East and
+# West of Greenwich, of one hour each, Nigeria falling into the zone with a
+# standard of one hour fast on Greenwich Mean Time.  Nigeria standard time is
+# now 30 minutes in advance of Greenwich Mean Time ... according to the new
+# proposal, standard time will be advanced another 30 minutes".  It was further
+# proposed that the firing of the time guns likewise be adjusted by 30 minutes
+# to compensate.
+# From Tim Parenti (2020-12-10), per P Chan (2020-12-11):
+# The text of Ordinance 18 of 1919, published in Nigeria Gazette, Vol 6, No 52,
+# shows that the change was assented to the following day and took effect "on
+# the 1st day of September, 1919."
+# Nigeria Gazette and Supplements 1919 Jan-Dec, Reference: 73266B-40,
+# img 245-246
+# https://microform.digital/boa/collections/77/volumes/539/nigeria-lagos-1887-1919
+
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
-Zone	Africa/Lagos	0:13:36 -	LMT	1919 Sep
+Zone	Africa/Lagos	0:13:35 -	LMT	1905 Jul  1
+			0:00	-	GMT	1908 Jul  1
+			0:13:35	-	LMT	1914 Jan  1
+			0:30	-	+0030	1919 Sep  1
 			1:00	-	WAT
 Link Africa/Lagos Africa/Bangui	     # Central African Republic
 Link Africa/Lagos Africa/Brazzaville # Rep. of the Congo
@@ -1321,8 +1476,21 @@ Zone	Africa/Sao_Tome	 0:26:56 -	LMT	1884
 # See Africa/Abidjan.
 
 # Seychelles
+
+# From P Chan (2020-11-27):
+# Standard Time was adopted on 1907-01-01.
+#
+# Standard Time Ordinance (Chapter 237)
+# The Laws of Seychelles in Force on the 31st December, 1971, Vol. 6, p 571
+# https://books.google.com/books?id=efE-AQAAIAAJ&pg=PA571
+#
+# From Tim Parenti (2020-12-05):
+# A footnote on https://books.google.com/books?id=DYdDAQAAMAAJ&pg=PA1689
+# confirms that Ordinance No. 9 of 1906 "was brought into force on the 1st
+# January, 1907."
+
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
-Zone	Indian/Mahe	3:41:48 -	LMT	1906 Jun # Victoria
+Zone	Indian/Mahe	3:41:48 -	LMT	1907 Jan  1 # Victoria
 			4:00	-	+04
 # From Paul Eggert (2001-05-30):
 # Aldabra, Farquhar, and Desroches, originally dependencies of the

--- a/make/data/tzdata/asia
+++ b/make/data/tzdata/asia
@@ -1746,40 +1746,180 @@ Zone	Asia/Baghdad	2:57:40	-	LMT	1890
 # high on my favorite-country list (and not only because my wife's
 # family is from India).
 
-# From Shanks & Pottenger:
+# From P Chan (2020-10-27), with corrections:
+#
+# 1940-1946 Supplement No. 2 to the Palestine Gazette
+# # issue page  Order No.   dated      start        end         note
+# 1 1010  729  67 of 1940 1940-05-22 1940-05-31* 1940-09-30* revoked by #2
+# 2 1013  758  73 of 1940 1940-05-31 1940-05-31  1940-09-30
+# 3 1055 1574 196 of 1940 1940-11-06 1940-11-16  1940-12-31
+# 4 1066 1811 208 of 1940 1940-12-17 1940-12-31  1941-12-31
+# 5 1156 1967 116 of 1941 1941-12-16 1941-12-31  1942-12-31* amended by #6
+# 6 1228 1608  86 of 1942 1942-10-14 1941-12-31  1942-10-31
+# 7 1256  279  21 of 1943 1943-03-18 1943-03-31  1943-10-31
+# 8 1323  249  19 of 1944 1944-03-13 1944-03-31  1944-10-31
+# 9 1402  328  20 of 1945 1945-04-05 1945-04-15  1945-10-31
+#10 1487  596  14 of 1946 1946-04-04 1946-04-15  1946-10-31
+#
+# 1948 Iton Rishmi (Official Gazette of the Provisional Government)
+# #    issue    page   dated      start       end
+#11 2             7 1948-05-20 1948-05-22 1948-10-31*
+#	^This moved timezone to +04, replaced by #12 from 1948-08-31 24:00 GMT.
+#12 17 (Annex B) 84 1948-08-22 1948-08-31 1948-10-31
+#
+# 1949-2000 Kovetz HaTakanot (Collection of Regulations)
+# # issue page  dated      start       end            note
+#13    6  133 1949-03-23 1949-04-30  1949-10-31
+#14   80  755 1950-03-17 1950-04-15  1950-09-14
+#15  164  782 1951-03-22 1951-03-31  1951-09-29* amended by #16
+#16  206 1940 1951-09-23 ----------  1951-10-22* amended by #17
+#17  212   78 1951-10-19 ----------  1951-11-10
+#18  254  652 1952-03-03 1952-04-19  1952-09-27* amended by #19
+#19  300   11 1952-09-15 ----------  1952-10-18
+#20  348  817 1953-03-03 1953-04-11  1953-09-12
+#21  420  385 1954-02-17 1954-06-12  1954-09-11
+#22  497  548 1955-01-14 1955-06-11  1955-09-10
+#23  591  608 1956-03-12 1956-06-02  1956-09-29
+#24  680  957 1957-02-08 1957-04-27  1957-09-21
+#25 3192 1418 1974-06-28 1974-07-06  1974-10-12
+#26 3322 1389 1975-04-03 1975-04-19  1975-08-30
+#27 4146 2089 1980-07-15 1980-08-02  1980-09-13
+#28 4604 1081 1984-02-22 1984-05-05* 1984-08-25* revoked by #29
+#29 4619 1312 1984-04-06 1984-05-05  1984-08-25
+#30 4744  475 1984-12-23 1985-04-13  1985-09-14* amended by #31
+#31 4851 1848 1985-08-18 ----------  1985-08-31
+#32 4932  899 1986-04-22 1986-05-17  1986-09-06
+#33 5013  580 1987-02-15 1987-04-18* 1987-08-22* revoked by #34
+#34 5021  744 1987-03-30 1987-04-14  1987-09-12
+#35 5096  659 1988-02-14 1988-04-09  1988-09-03
+#36 5167  514 1989-02-03 1989-04-29  1989-09-02
+#37 5248  375 1990-01-23 1990-03-24  1990-08-25
+#38 5335  612 1991-02-10 1991-03-09* 1991-08-31	 amended by #39
+#			 1992-03-28  1992-09-05
+#39 5339  709 1991-03-04 1991-03-23  ----------
+#40 5506  503 1993-02-18 1993-04-02  1993-09-05
+#			 1994-04-01  1994-08-28
+#			 1995-03-31  1995-09-03
+#41 5731  438 1996-01-01 1996-03-14  1996-09-15
+#			 1997-03-13* 1997-09-18* overridden by 1997 Temp Prov
+#			 1998-03-19* 1998-09-17* revoked by #42
+#42 5853 1243 1997-09-18 1998-03-19  1998-09-05
+#43 5937   77 1998-10-18 1999-04-02  1999-09-03
+#			 2000-04-14* 2000-09-15* revoked by #44
+#			 2001-04-13* 2001-09-14* revoked by #44
+#44 6024   39 2000-03-14 2000-04-14  2000-10-22* overridden by 2000 Temp Prov
+#			 2001-04-06* 2001-10-10* overridden by 2000 Temp Prov
+#			 2002-03-29* 2002-10-29* overridden by 2000 Temp Prov
+#
+# These are laws enacted by the Knesset since the Minister could only alter the
+# transition dates at least six months in advanced under the 1992 Law.
+#				dated		start		end
+# 1997 Temporary Provisions	1997-03-06	1997-03-20	1997-09-13
+# 2000 Temporary Provisions	2000-07-28	----------	2000-10-06
+#						2001-04-09	2001-09-24
+#						2002-03-29	2002-10-07
+#						2003-03-28	2003-10-03
+#						2004-04-07	2004-09-22
+# Note:
+# Transition times in 1940-1957 (#1-#24) were midnight GMT,
+# in 1974-1998 (#25-#42 and the 1997 Temporary Provisions) were midnight,
+# in 1999-April 2000 (#43,#44) were 02:00,
+# in the 2000 Temporary Provisions were 01:00.
+#
+# -----------------------------------------------------------------------------
+# Links:
+# 1 https://findit.library.yale.edu/images_layout/view?parentoid=15537490&increment=687
+# 2 https://findit.library.yale.edu/images_layout/view?parentoid=15537490&increment=716
+# 3 https://findit.library.yale.edu/images_layout/view?parentoid=15537491&increment=721
+# 4 https://findit.library.yale.edu/images_layout/view?parentoid=15537491&increment=958
+# 5 https://findit.library.yale.edu/images_layout/view?parentoid=15537502&increment=558
+# 6 https://findit.library.yale.edu/images_layout/view?parentoid=15537511&increment=105
+# 7 https://findit.library.yale.edu/images_layout/view?parentoid=15537516&increment=278
+# 8 https://findit.library.yale.edu/images_layout/view?parentoid=15537522&increment=248
+# 9 https://findit.library.yale.edu/images_layout/view?parentoid=15537530&increment=329
+#10 https://findit.library.yale.edu/images_layout/view?parentoid=15537537&increment=601
+#11 https://www.nevo.co.il/law_word/law12/er-002.pdf#page=3
+#12 https://www.nevo.co.il/law_word/law12/er-017-t2.pdf#page=4
+#13 https://www.nevo.co.il/law_word/law06/tak-0006.pdf#page=3
+#14 https://www.nevo.co.il/law_word/law06/tak-0080.pdf#page=7
+#15 https://www.nevo.co.il/law_word/law06/tak-0164.pdf#page=10
+#16 https://www.nevo.co.il/law_word/law06/tak-0206.pdf#page=4
+#17 https://www.nevo.co.il/law_word/law06/tak-0212.pdf#page=2
+#18 https://www.nevo.co.il/law_word/law06/tak-0254.pdf#page=4
+#19 https://www.nevo.co.il/law_word/law06/tak-0300.pdf#page=5
+#20 https://www.nevo.co.il/law_word/law06/tak-0348.pdf#page=3
+#21 https://www.nevo.co.il/law_word/law06/tak-0420.pdf#page=5
+#22 https://www.nevo.co.il/law_word/law06/tak-0497.pdf#page=10
+#23 https://www.nevo.co.il/law_word/law06/tak-0591.pdf#page=6
+#24 https://www.nevo.co.il/law_word/law06/tak-0680.pdf#page=3
+#25 https://www.nevo.co.il/law_word/law06/tak-3192.pdf#page=2
+#26 https://www.nevo.co.il/law_word/law06/tak-3322.pdf#page=5
+#27 https://www.nevo.co.il/law_word/law06/tak-4146.pdf#page=2
+#28 https://www.nevo.co.il/law_word/law06/tak-4604.pdf#page=7
+#29 https://www.nevo.co.il/law_word/law06/tak-4619.pdf#page=2
+#30 https://www.nevo.co.il/law_word/law06/tak-4744.pdf#page=11
+#31 https://www.nevo.co.il/law_word/law06/tak-4851.pdf#page=2
+#32 https://www.nevo.co.il/law_word/law06/tak-4932.pdf#page=19
+#33 https://www.nevo.co.il/law_word/law06/tak-5013.pdf#page=8
+#34 https://www.nevo.co.il/law_word/law06/tak-5021.pdf#page=8
+#35 https://www.nevo.co.il/law_word/law06/tak-5096.pdf#page=3
+#36 https://www.nevo.co.il/law_word/law06/tak-5167.pdf#page=2
+#37 https://www.nevo.co.il/law_word/law06/tak-5248.pdf#page=7
+#38 https://www.nevo.co.il/law_word/law06/tak-5335.pdf#page=6
+#39 https://www.nevo.co.il/law_word/law06/tak-5339.pdf#page=7
+#40 https://www.nevo.co.il/law_word/law06/tak-5506.pdf#page=19
+#41 https://www.nevo.co.il/law_word/law06/tak-5731.pdf#page=2
+#42 https://www.nevo.co.il/law_word/law06/tak-5853.pdf#page=3
+#43 https://www.nevo.co.il/law_word/law06/tak-5937.pdf#page=9
+#44 https://www.nevo.co.il/law_word/law06/tak-6024.pdf#page=4
+#
+# Time Determination (Temporary Provisions) Law, 1997
+# https://www.nevo.co.il/law_html/law19/p201_003.htm
+#
+# Time Determination (Temporary Provisions) Law, 2000
+# https://www.nevo.co.il/law_html/law19/p201_004.htm
+#
+# Time Determination Law, 1992 and amendments
+# https://www.nevo.co.il/law_html/law01/p201_002.htm
+# https://main.knesset.gov.il/Activity/Legislation/Laws/Pages/LawPrimary.aspx?lawitemid=2001174
+
+# From Paul Eggert (2020-10-27):
+# Several of the midnight transitions mentioned above are ambiguous;
+# are they 00:00, 00:00s, 24:00, or 24:00s?  When resolving these ambiguities,
+# try to minimize changes from previous tzdb versions, for lack of better info.
+# Commentary from previous versions is included below, to help explain this.
+
 # Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
-Rule	Zion	1940	only	-	Jun	 1	0:00	1:00	D
-Rule	Zion	1942	1944	-	Nov	 1	0:00	0	S
-Rule	Zion	1943	only	-	Apr	 1	2:00	1:00	D
-Rule	Zion	1944	only	-	Apr	 1	0:00	1:00	D
-Rule	Zion	1945	only	-	Apr	16	0:00	1:00	D
-Rule	Zion	1945	only	-	Nov	 1	2:00	0	S
-Rule	Zion	1946	only	-	Apr	16	2:00	1:00	D
-Rule	Zion	1946	only	-	Nov	 1	0:00	0	S
-Rule	Zion	1948	only	-	May	23	0:00	2:00	DD
-Rule	Zion	1948	only	-	Sep	 1	0:00	1:00	D
-Rule	Zion	1948	1949	-	Nov	 1	2:00	0	S
-Rule	Zion	1949	only	-	May	 1	0:00	1:00	D
-Rule	Zion	1950	only	-	Apr	16	0:00	1:00	D
-Rule	Zion	1950	only	-	Sep	15	3:00	0	S
-Rule	Zion	1951	only	-	Apr	 1	0:00	1:00	D
-Rule	Zion	1951	only	-	Nov	11	3:00	0	S
-Rule	Zion	1952	only	-	Apr	20	2:00	1:00	D
-Rule	Zion	1952	only	-	Oct	19	3:00	0	S
-Rule	Zion	1953	only	-	Apr	12	2:00	1:00	D
-Rule	Zion	1953	only	-	Sep	13	3:00	0	S
-Rule	Zion	1954	only	-	Jun	13	0:00	1:00	D
-Rule	Zion	1954	only	-	Sep	12	0:00	0	S
-Rule	Zion	1955	only	-	Jun	11	2:00	1:00	D
-Rule	Zion	1955	only	-	Sep	11	0:00	0	S
-Rule	Zion	1956	only	-	Jun	 3	0:00	1:00	D
-Rule	Zion	1956	only	-	Sep	30	3:00	0	S
-Rule	Zion	1957	only	-	Apr	29	2:00	1:00	D
-Rule	Zion	1957	only	-	Sep	22	0:00	0	S
-Rule	Zion	1974	only	-	Jul	 7	0:00	1:00	D
-Rule	Zion	1974	only	-	Oct	13	0:00	0	S
-Rule	Zion	1975	only	-	Apr	20	0:00	1:00	D
-Rule	Zion	1975	only	-	Aug	31	0:00	0	S
+Rule	Zion	1940	only	-	May	31	24:00u	1:00	D
+Rule	Zion	1940	only	-	Sep	30	24:00u	0	S
+Rule	Zion	1940	only	-	Nov	16	24:00u	1:00	D
+Rule	Zion	1942	1946	-	Oct	31	24:00u	0	S
+Rule	Zion	1943	1944	-	Mar	31	24:00u	1:00	D
+Rule	Zion	1945	1946	-	Apr	15	24:00u	1:00	D
+Rule	Zion	1948	only	-	May	22	24:00u	2:00	DD
+Rule	Zion	1948	only	-	Aug	31	24:00u	1:00	D
+Rule	Zion	1948	1949	-	Oct	31	24:00u	0	S
+Rule	Zion	1949	only	-	Apr	30	24:00u	1:00	D
+Rule	Zion	1950	only	-	Apr	15	24:00u	1:00	D
+Rule	Zion	1950	only	-	Sep	14	24:00u	0	S
+Rule	Zion	1951	only	-	Mar	31	24:00u	1:00	D
+Rule	Zion	1951	only	-	Nov	10	24:00u	0	S
+Rule	Zion	1952	only	-	Apr	19	24:00u	1:00	D
+Rule	Zion	1952	only	-	Oct	18	24:00u	0	S
+Rule	Zion	1953	only	-	Apr	11	24:00u	1:00	D
+Rule	Zion	1953	only	-	Sep	12	24:00u	0	S
+Rule	Zion	1954	only	-	Jun	12	24:00u	1:00	D
+Rule	Zion	1954	only	-	Sep	11	24:00u	0	S
+Rule	Zion	1955	only	-	Jun	11	24:00u	1:00	D
+Rule	Zion	1955	only	-	Sep	10	24:00u	0	S
+Rule	Zion	1956	only	-	Jun	 2	24:00u	1:00	D
+Rule	Zion	1956	only	-	Sep	29	24:00u	0	S
+Rule	Zion	1957	only	-	Apr	27	24:00u	1:00	D
+Rule	Zion	1957	only	-	Sep	21	24:00u	0	S
+Rule	Zion	1974	only	-	Jul	 6	24:00	1:00	D
+Rule	Zion	1974	only	-	Oct	12	24:00	0	S
+Rule	Zion	1975	only	-	Apr	19	24:00	1:00	D
+Rule	Zion	1975	only	-	Aug	30	24:00	0	S
 
 # From Alois Treindl (2019-03-06):
 # http://www.moin.gov.il/Documents/שעון%20קיץ/clock-50-years-7-2014.pdf
@@ -1792,25 +1932,24 @@ Rule	Zion	1975	only	-	Aug	31	0:00	0	S
 # From Paul Eggert (2019-03-06):
 # Also see this thread about the moin.gov.il URL:
 # https://mm.icann.org/pipermail/tz/2018-November/027194.html
-Rule	Zion	1980	only	-	Aug	 2	0:00	1:00	D
-Rule	Zion	1980	only	-	Sep	13	1:00	0	S
-Rule	Zion	1984	only	-	May	 5	0:00	1:00	D
-Rule	Zion	1984	only	-	Aug	25	1:00	0	S
+Rule	Zion	1980	only	-	Aug	 2	24:00s	1:00	D
+Rule	Zion	1980	only	-	Sep	13	24:00s	0	S
+Rule	Zion	1984	only	-	May	 5	24:00s	1:00	D
+Rule	Zion	1984	only	-	Aug	25	24:00s	0	S
 
-# From Shanks & Pottenger:
-Rule	Zion	1985	only	-	Apr	14	0:00	1:00	D
-Rule	Zion	1985	only	-	Sep	15	0:00	0	S
-Rule	Zion	1986	only	-	May	18	0:00	1:00	D
-Rule	Zion	1986	only	-	Sep	 7	0:00	0	S
-Rule	Zion	1987	only	-	Apr	15	0:00	1:00	D
-Rule	Zion	1987	only	-	Sep	13	0:00	0	S
+Rule	Zion	1985	only	-	Apr	13	24:00	1:00	D
+Rule	Zion	1985	only	-	Aug	31	24:00	0	S
+Rule	Zion	1986	only	-	May	17	24:00	1:00	D
+Rule	Zion	1986	only	-	Sep	 6	24:00	0	S
+Rule	Zion	1987	only	-	Apr	14	24:00	1:00	D
+Rule	Zion	1987	only	-	Sep	12	24:00	0	S
 
 # From Avigdor Finkelstein (2014-03-05):
 # I check the Parliament (Knesset) records and there it's stated that the
 # [1988] transition should take place on Saturday night, when the Sabbath
 # ends and changes to Sunday.
-Rule	Zion	1988	only	-	Apr	10	0:00	1:00	D
-Rule	Zion	1988	only	-	Sep	 4	0:00	0	S
+Rule	Zion	1988	only	-	Apr	 9	24:00	1:00	D
+Rule	Zion	1988	only	-	Sep	 3	24:00	0	S
 
 # From Ephraim Silverberg
 # (1997-03-04, 1998-03-16, 1998-12-28, 2000-01-17, 2000-07-25, 2004-12-22,
@@ -1840,14 +1979,14 @@ Rule	Zion	1988	only	-	Sep	 4	0:00	0	S
 # (the eve of the 7th of Tishrei in the lunar Hebrew calendar).
 
 # Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
-Rule	Zion	1989	only	-	Apr	30	0:00	1:00	D
-Rule	Zion	1989	only	-	Sep	 3	0:00	0	S
-Rule	Zion	1990	only	-	Mar	25	0:00	1:00	D
-Rule	Zion	1990	only	-	Aug	26	0:00	0	S
-Rule	Zion	1991	only	-	Mar	24	0:00	1:00	D
-Rule	Zion	1991	only	-	Sep	 1	0:00	0	S
-Rule	Zion	1992	only	-	Mar	29	0:00	1:00	D
-Rule	Zion	1992	only	-	Sep	 6	0:00	0	S
+Rule	Zion	1989	only	-	Apr	29	24:00	1:00	D
+Rule	Zion	1989	only	-	Sep	 2	24:00	0	S
+Rule	Zion	1990	only	-	Mar	24	24:00	1:00	D
+Rule	Zion	1990	only	-	Aug	25	24:00	0	S
+Rule	Zion	1991	only	-	Mar	23	24:00	1:00	D
+Rule	Zion	1991	only	-	Aug	31	24:00	0	S
+Rule	Zion	1992	only	-	Mar	28	24:00	1:00	D
+Rule	Zion	1992	only	-	Sep	 5	24:00	0	S
 Rule	Zion	1993	only	-	Apr	 2	0:00	1:00	D
 Rule	Zion	1993	only	-	Sep	 5	0:00	0	S
 
@@ -1876,10 +2015,10 @@ Rule	Zion	1995	only	-	Sep	 3	0:00	0	S
 #       where YYYY is the relevant year.
 
 # Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
-Rule	Zion	1996	only	-	Mar	15	0:00	1:00	D
-Rule	Zion	1996	only	-	Sep	16	0:00	0	S
-Rule	Zion	1997	only	-	Mar	21	0:00	1:00	D
-Rule	Zion	1997	only	-	Sep	14	0:00	0	S
+Rule	Zion	1996	only	-	Mar	14	24:00	1:00	D
+Rule	Zion	1996	only	-	Sep	15	24:00	0	S
+Rule	Zion	1997	only	-	Mar	20	24:00	1:00	D
+Rule	Zion	1997	only	-	Sep	13	24:00	0	S
 Rule	Zion	1998	only	-	Mar	20	0:00	1:00	D
 Rule	Zion	1998	only	-	Sep	 6	0:00	0	S
 Rule	Zion	1999	only	-	Apr	 2	2:00	1:00	D
@@ -1931,14 +2070,15 @@ Rule	Zion	2010	only	-	Sep	12	2:00	0	S
 Rule	Zion	2011	only	-	Oct	 2	2:00	0	S
 Rule	Zion	2012	only	-	Sep	23	2:00	0	S
 
-# From Ephraim Silverberg (2013-06-27):
-# On June 23, 2013, the Israeli government approved changes to the
-# Time Decree Law.  The next day, the changes passed the First Reading
-# in the Knesset.  The law is expected to pass the Second and Third
-# (final) Readings by the beginning of September 2013.
-#
-# As of 2013, DST starts at 02:00 on the Friday before the last Sunday
-# in March.  DST ends at 02:00 on the last Sunday of October.
+# From Ephraim Silverberg (2020-10-26):
+# The current time law (2013) from the State of Israel can be viewed
+# (in Hebrew) at:
+# ftp://ftp.cs.huji.ac.il/pub/tz/israel/announcements/2013+law.pdf
+# It translates to:
+# Every year, in the period from the Friday before the last Sunday in
+# the month of March at 02:00 a.m. until the last Sunday of the month
+# of October at 02:00 a.m., Israel Time will be advanced an additional
+# hour such that it will be UTC+3.
 
 # Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
 Rule	Zion	2013	max	-	Mar	Fri>=23	2:00	1:00	D

--- a/make/data/tzdata/australasia
+++ b/make/data/tzdata/australasia
@@ -37,16 +37,13 @@
 # Please see the notes below for the controversy about "EST" versus "AEST" etc.
 
 # Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
-Rule	Aus	1917	only	-	Jan	 1	0:01	1:00	D
-Rule	Aus	1917	only	-	Mar	25	2:00	0	S
-Rule	Aus	1942	only	-	Jan	 1	2:00	1:00	D
-Rule	Aus	1942	only	-	Mar	29	2:00	0	S
-Rule	Aus	1942	only	-	Sep	27	2:00	1:00	D
-Rule	Aus	1943	1944	-	Mar	lastSun	2:00	0	S
-Rule	Aus	1943	only	-	Oct	 3	2:00	1:00	D
-# Go with Whitman and the Australian National Standards Commission, which
-# says W Australia didn't use DST in 1943/1944.  Ignore Whitman's claim that
-# 1944/1945 was just like 1943/1944.
+Rule	Aus	1917	only	-	Jan	 1	2:00s	1:00	D
+Rule	Aus	1917	only	-	Mar	lastSun	2:00s	0	S
+Rule	Aus	1942	only	-	Jan	 1	2:00s	1:00	D
+Rule	Aus	1942	only	-	Mar	lastSun	2:00s	0	S
+Rule	Aus	1942	only	-	Sep	27	2:00s	1:00	D
+Rule	Aus	1943	1944	-	Mar	lastSun	2:00s	0	S
+Rule	Aus	1943	only	-	Oct	 3	2:00s	1:00	D
 
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 # Northern Territory
@@ -138,8 +135,12 @@ Zone Australia/Adelaide	9:14:20 -	LMT	1895 Feb
 # says King Island didn't observe DST from WWII until late 1971.
 #
 # Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
+Rule	AT	1916	only	-	Oct	Sun>=1	2:00s	1:00	D
+Rule	AT	1917	only	-	Mar	lastSun	2:00s	0	S
+Rule	AT	1917	1918	-	Oct	Sun>=22	2:00s	1:00	D
+Rule	AT	1918	1919	-	Mar	Sun>=1	2:00s	0	S
 Rule	AT	1967	only	-	Oct	Sun>=1	2:00s	1:00	D
-Rule	AT	1968	only	-	Mar	lastSun	2:00s	0	S
+Rule	AT	1968	only	-	Mar	Sun>=29	2:00s	0	S
 Rule	AT	1968	1985	-	Oct	lastSun	2:00s	1:00	D
 Rule	AT	1969	1971	-	Mar	Sun>=8	2:00s	0	S
 Rule	AT	1972	only	-	Feb	lastSun	2:00s	0	S
@@ -159,14 +160,8 @@ Rule	AT	2007	only	-	Mar	lastSun	2:00s	0	S
 Rule	AT	2008	max	-	Apr	Sun>=1	2:00s	0	S
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone Australia/Hobart	9:49:16	-	LMT	1895 Sep
-			10:00	-	AEST	1916 Oct  1  2:00
-			10:00	1:00	AEDT	1917 Feb
+			10:00	AT	AE%sT	1919 Oct 24
 			10:00	Aus	AE%sT	1967
-			10:00	AT	AE%sT
-Zone Australia/Currie	9:35:28	-	LMT	1895 Sep
-			10:00	-	AEST	1916 Oct  1  2:00
-			10:00	1:00	AEDT	1917 Feb
-			10:00	Aus	AE%sT	1971 Jul
 			10:00	AT	AE%sT
 
 # Victoria
@@ -896,13 +891,36 @@ Zone	Pacific/Wake	11:06:28 -	LMT	1901
 
 
 # Vanuatu
+
+# From P Chan (2020-11-27):
+# Joint Daylight Saving Regulation No 59 of 1973
+# New Hebrides Condominium Gazette No 336. December 1973
+# http://www.paclii.org/vu/other/VUNHGovGaz//1973/11.pdf#page=15
+#
+# Joint Daylight Saving (Repeal) Regulation No 10 of 1974
+# New Hebrides Condominium Gazette No 336. March 1974
+# http://www.paclii.org/vu/other/VUNHGovGaz//1974/3.pdf#page=11
+#
+# Summer Time Act No. 35 of 1982 [commenced 1983-09-01]
+# http://www.paclii.org/vu/other/VUGovGaz/1982/32.pdf#page=48
+#
+# Summer Time Act (Cap 157)
+# Laws of the Republic of Vanuatu Revised Edition 1988
+# http://www.paclii.org/cgi-bin/sinodisp/vu/legis/consol_act1988/sta147/sta147.html
+#
+# Summer Time (Amendment) Act No. 6 of 1991 [commenced 1991-11-11]
+# http://www.paclii.org/vu/legis/num_act/sta1991227/
+#
+# Summer Time (Repeal) Act No. 4 of 1993 [commenced 1993-05-03]
+# http://www.paclii.org/vu/other/VUGovGaz/1993/15.pdf#page=59
+
 # Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
-Rule	Vanuatu	1983	only	-	Sep	25	0:00	1:00	-
-Rule	Vanuatu	1984	1991	-	Mar	Sun>=23	0:00	0	-
-Rule	Vanuatu	1984	only	-	Oct	23	0:00	1:00	-
-Rule	Vanuatu	1985	1991	-	Sep	Sun>=23	0:00	1:00	-
-Rule	Vanuatu	1992	1993	-	Jan	Sun>=23	0:00	0	-
-Rule	Vanuatu	1992	only	-	Oct	Sun>=23	0:00	1:00	-
+Rule	Vanuatu	1973	only	-	Dec	22	12:00u	1:00	-
+Rule	Vanuatu	1974	only	-	Mar	30	12:00u	0	-
+Rule	Vanuatu	1983	1991	-	Sep	Sat>=22	24:00	1:00	-
+Rule	Vanuatu	1984	1991	-	Mar	Sat>=22	24:00	0	-
+Rule	Vanuatu	1992	1993	-	Jan	Sat>=22	24:00	0	-
+Rule	Vanuatu	1992	only	-	Oct	Sat>=22	24:00	1:00	-
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Pacific/Efate	11:13:16 -	LMT	1912 Jan 13 # Vila
 			11:00	Vanuatu	+11/+12
@@ -980,6 +998,25 @@ Zone	Pacific/Wallis	12:15:20 -	LMT	1901
 # about fading curtains and crazed farm animals."
 # Electronic Journal of Australian and New Zealand History (1997-03-03)
 # http://www.jcu.edu.au/aff/history/reviews/davison.htm
+
+# From P Chan (2020-11-20):
+# Daylight Saving Act 1916 (No. 40 of 1916) [1916-12-21, commenced 1917-01-01]
+# http://classic.austlii.edu.au/au/legis/cth/num_act/dsa1916401916192/
+#
+# Daylight Saving Repeal Act 1917 (No. 35 of 1917) [1917-09-25]
+# http://classic.austlii.edu.au/au/legis/cth/num_act/dsra1917351917243/
+#
+# Statutory Rules 1941, No. 323 [1941-12-24]
+# https://www.legislation.gov.au/Details/C1941L00323
+#
+# Statutory Rules 1942, No. 392 [1942-09-10]
+# https://www.legislation.gov.au/Details/C1942L00392
+#
+# Statutory Rules 1943, No. 241 [1943-09-29]
+# https://www.legislation.gov.au/Details/C1943L00241
+#
+# All transition times should be 02:00 standard time.
+
 
 # From Paul Eggert (2005-12-08):
 # Implementation Dates of Daylight Saving Time within Australia
@@ -1372,6 +1409,27 @@ Zone	Pacific/Wallis	12:15:20 -	LMT	1901
 # See "southeast Australia" above for 2008 and later.
 
 # Tasmania
+
+# From P Chan (2020-11-20):
+# Tasmania observed DST in 1916-1919.
+#
+# Daylight Saving Act, 1916 (7 Geo V, No 2) [1916-09-22]
+# http://classic.austlii.edu.au/au/legis/tas/num_act/tdsa19167gvn2267/
+#
+# Daylight Saving Amendment Act, 1917 (8 Geo V, No 5) [1917-10-01]
+# http://classic.austlii.edu.au/au/legis/tas/num_act/tdsaa19178gvn5347/
+#
+# Daylight Saving Act Repeal Act, 1919 (10 Geo V, No 9) [1919-10-24]
+# http://classic.austlii.edu.au/au/legis/tas/num_act/tdsara191910gvn9339/
+#
+# King Island is mentioned in the 1967 Act but not the 1968 Act.
+# Therefore it possibly observed DST from 1968/69.
+#
+# Daylight Saving Act 1967 (No. 33 of 1967) [1967-09-22]
+# http://classic.austlii.edu.au/au/legis/tas/num_act/dsa196733o1967211/
+#
+# Daylight Saving Act 1968 (No. 42 of 1968) [1968-10-15]
+# http://classic.austlii.edu.au/au/legis/tas/num_act/dsa196842o1968211/
 
 # The rules for 1967 through 1991 were reported by George Shepherd
 # via Simon Woodhead via Robert Elz (1991-03-06):

--- a/make/data/tzdata/backward
+++ b/make/data/tzdata/backward
@@ -72,6 +72,7 @@ Link	Atlantic/Faroe		Atlantic/Faeroe
 Link	Europe/Oslo		Atlantic/Jan_Mayen
 Link	Australia/Sydney	Australia/ACT
 Link	Australia/Sydney	Australia/Canberra
+Link	Australia/Hobart	Australia/Currie
 Link	Australia/Lord_Howe	Australia/LHI
 Link	Australia/Sydney	Australia/NSW
 Link	Australia/Darwin	Australia/North

--- a/make/data/tzdata/etcetera
+++ b/make/data/tzdata/etcetera
@@ -26,12 +26,11 @@
 # This file is in the public domain, so clarified as of
 # 2009-05-17 by Arthur David Olson.
 
-# These entries are mostly present for historical reasons, so that
-# people in areas not otherwise covered by the tz files could "zic -l"
-# to a timezone that was right for their area.  These days, the
-# tz files cover almost all the inhabited world, and the only practical
-# need now for the entries that are not on UTC are for ships at sea
-# that cannot use POSIX TZ settings.
+# These entries are for uses not otherwise covered by the tz database.
+# Their main practical use is for platforms like Android that lack
+# support for POSIX-style TZ strings.  On such platforms these entries
+# can be useful if the timezone database is wrong or if a ship or
+# aircraft at sea is not in a timezone.
 
 # Starting with POSIX 1003.1-2001, the entries below are all
 # unnecessary as settings for the TZ environment variable.  E.g.,

--- a/make/data/tzdata/europe
+++ b/make/data/tzdata/europe
@@ -2915,6 +2915,19 @@ Zone Europe/Astrakhan	 3:12:12 -	LMT	1924 May
 # The law has been published today on
 # http://publication.pravo.gov.ru/Document/View/0001201810110037
 
+# From Alexander Krivenyshev (2020-11-27):
+# The State Duma approved (Nov 24, 2020) the transition of the Volgograd
+# region to the Moscow time zone....
+# https://sozd.duma.gov.ru/bill/1012130-7
+#
+# From Stepan Golosunov (2020-12-05):
+# Currently proposed text for the second reading (expected on December 8) ...
+# changes the date to December 27. https://v1.ru/text/gorod/2020/12/04/69601031/
+#
+# From Stepan Golosunov (2020-12-22):
+# The law was published today on
+# http://publication.pravo.gov.ru/Document/View/0001202012220002
+
 Zone Europe/Volgograd	 2:57:40 -	LMT	1920 Jan  3
 			 3:00	-	+03	1930 Jun 21
 			 4:00	-	+04	1961 Nov 11
@@ -2924,7 +2937,8 @@ Zone Europe/Volgograd	 2:57:40 -	LMT	1920 Jan  3
 			 3:00	Russia	+03/+04	2011 Mar 27  2:00s
 			 4:00	-	+04	2014 Oct 26  2:00s
 			 3:00	-	+03	2018 Oct 28  2:00s
-			 4:00	-	+04
+			 4:00	-	+04	2020 Dec 27  2:00s
+			 3:00	-	+03
 
 # From Paul Eggert (2016-11-11):
 # Europe/Saratov covers:

--- a/make/data/tzdata/leapseconds
+++ b/make/data/tzdata/leapseconds
@@ -29,6 +29,10 @@
 # NIST format leap-seconds.list file, which can be copied from
 # <ftp://ftp.nist.gov/pub/time/leap-seconds.list>
 # or <ftp://ftp.boulder.nist.gov/pub/time/leap-seconds.list>.
+# The NIST file is used instead of its IERS upstream counterpart
+# <https://hpiers.obspm.fr/iers/bul/bulc/ntp/leap-seconds.list>
+# because under US law the NIST file is public domain
+# whereas the IERS file's copyright and license status is unclear.
 # For more about leap-seconds.list, please see
 # The NTP Timescale and Leap Seconds
 # <https://www.eecis.udel.edu/~mills/leap.html>.

--- a/make/data/tzdata/northamerica
+++ b/make/data/tzdata/northamerica
@@ -2257,7 +2257,7 @@ Zone America/Creston	-7:46:04 -	LMT	1884
 #     to say eight hours behind Greenwich Time.
 #
 # * O.I.C. 1980/02 INTERPRETATION ACT
-#   [no online source found]
+#   https://mm.icann.org/pipermail/tz/attachments/20201125/d5adc93b/CAYTOIC1980-02DST1980-01-04-0001.pdf
 #
 # * Yukon Daylight Saving Time, YOIC 1987/56
 #   https://www.canlii.org/en/yk/laws/regu/yoic-1987-56/latest/yoic-1987-56.html
@@ -2958,12 +2958,38 @@ Zone America/Tijuana	-7:48:04 -	LMT	1922 Jan  1  0:11:56
 #
 # For 1899 Milne gives -5:09:29.5; round that.
 #
+# From P Chan (2020-11-27, corrected on 2020-12-02):
+# There were two periods of DST observed in 1942-1945: 1942-05-01
+# midnight to 1944-12-31 midnight and 1945-02-01 to 1945-10-17 midnight.
+# "midnight" should mean 24:00 from the context.
+#
+# War Time Order 1942 [1942-05-01] and War Time (No. 2) Order 1942  [1942-09-29]
+# Appendix to the Statutes of 7 George VI. and the Year 1942. p 34, 43
+# https://books.google.com/books?id=5rlNAQAAIAAJ&pg=RA3-PA34
+# https://books.google.com/books?id=5rlNAQAAIAAJ&pg=RA3-PA43
+#
+# War Time Order 1943 [1943-03-31] and War Time Order 1944 [1943-12-29]
+# Appendix to the Statutes of 8 George VI. and the Year 1943. p 9-10, 28-29
+# https://books.google.com/books?id=5rlNAQAAIAAJ&pg=RA4-PA9
+# https://books.google.com/books?id=5rlNAQAAIAAJ&pg=RA4-PA28
+#
+# War Time Order 1945 [1945-01-31] and the Order which revoke War Time Order
+# 1945 [1945-10-16] Appendix to the Statutes of 9 George VI. and the Year
+# 1945. p 160, 247-248
+# https://books.google.com/books?id=5rlNAQAAIAAJ&pg=RA6-PA160
+# https://books.google.com/books?id=5rlNAQAAIAAJ&pg=RA6-PA247
+#
 # From Sue Williams (2006-12-07):
 # The Bahamas announced about a month ago that they plan to change their DST
 # rules to sync with the U.S. starting in 2007....
 # http://www.jonesbahamas.com/?c=45&a=10412
 
 # Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
+Rule	Bahamas	1942	only	-	May	 1	24:00	1:00	W
+Rule	Bahamas	1944	only	-	Dec	31	24:00	0	S
+Rule	Bahamas	1945	only	-	Feb	 1	0:00	1:00	W
+Rule	Bahamas	1945	only	-	Aug	14	23:00u	1:00	P # Peace
+Rule	Bahamas	1945	only	-	Oct	17	24:00	0	S
 Rule	Bahamas	1964	1975	-	Oct	lastSun	2:00	0	S
 Rule	Bahamas	1964	1975	-	Apr	lastSun	2:00	1:00	D
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
@@ -2987,34 +3013,161 @@ Zone America/Barbados	-3:58:29 -	LMT	1924 # Bridgetown
 			-4:00	Barb	A%sT
 
 # Belize
-# Whitman entirely disagrees with Shanks; go with Shanks & Pottenger.
+
+# From P Chan (2020-11-03):
+# Below are some laws related to the time in British Honduras/Belize:
+#
+# Definition of Time Ordinance, 1927 (No.4 of 1927) [1927-04-01]
+# Ordinances of British Honduras Passed in the Year 1927, p 19-20
+# https://books.google.com/books?id=LqEpAQAAMAAJ&pg=RA3-PA19
+#
+# Definition of Time (Amendment) Ordinance, 1942 (No. 5 of 1942) [1942-06-27]
+# Ordinances of British Honduras Passed in the Year 1942, p 31-32
+# https://books.google.com/books?id=h6MpAQAAMAAJ&pg=RA6-PA95-IA44
+#
+# Definition of Time Ordinance, 1945 (No. 19 of 1945) [1945-12-15]
+# Ordinances of British Honduras Passed in the Year 1945, p 49-50
+# https://books.google.com/books?id=xaMpAQAAMAAJ&pg=RA2-PP1
+#
+# Definition of Time Ordinance, 1947 (No. 1 of 1947) [1947-03-11]
+# Ordinances of British Honduras Passed in the Year 1947, p 1-2
+# https://books.google.com/books?id=xaMpAQAAMAAJ&pg=RA3-PA1
+#
+# Time (Definition of) Ordinance  (Chapter 180)
+# The Laws of British Honduras in Force on the 15th Day of September, 1958 , Volume IV, p 2580
+# https://books.google.com/books?id=v5QpAQAAMAAJ&pg=PA2580
+#
+# Time (Definition of) (Amendment) Ordinance, 1968 (No. 13 of 1968) [1968-08-03]
+# https://books.google.com/books?id=xij7KEB_58wC&pg=RA1-PA428-IA9
+#
+# Definition of Time Act (Chapter 339)
+# Law of Belize, Revised Edition 2000
+# http://www.belizelaw.org/web/lawadmin/PDF%20files/cap339.pdf
+
+# From Paul Eggert (2020-11-03):
+# The transitions below are derived from P Chan's sources, except that the
+# 1973 through 1983 transitions are from Shanks & Pottenger since we have
+# no better data there.
+
 # Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
-Rule	Belize	1918	1942	-	Oct	Sun>=2	0:00	0:30	-0530
-Rule	Belize	1919	1943	-	Feb	Sun>=9	0:00	0	CST
+Rule	Belize	1918	1941	-	Oct	Sat>=1	24:00	0:30	-0530
+Rule	Belize	1919	1942	-	Feb	Sat>=8	24:00	0	CST
+Rule	Belize	1942	only	-	Jun	27	24:00	1:00	CWT
+Rule	Belize	1945	only	-	Aug	14	23:00u	1:00	CPT
+Rule	Belize	1945	only	-	Dec	15	24:00	0	CST
+Rule	Belize	1947	1967	-	Oct	Sat>=1	24:00	0:30	-0530
+Rule	Belize	1948	1968	-	Feb	Sat>=8	24:00	0	CST
 Rule	Belize	1973	only	-	Dec	 5	0:00	1:00	CDT
 Rule	Belize	1974	only	-	Feb	 9	0:00	0	CST
 Rule	Belize	1982	only	-	Dec	18	0:00	1:00	CDT
 Rule	Belize	1983	only	-	Feb	12	0:00	0	CST
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
-Zone	America/Belize	-5:52:48 -	LMT	1912 Apr
+Zone	America/Belize	-5:52:48 -	LMT	1912 Apr  1
 			-6:00	Belize	%s
 
 # Bermuda
 
+# From Paul Eggert (2020-11-24):
 # For 1899 Milne gives -4:19:18.3 as the meridian of the clock tower,
-# Bermuda dockyard, Ireland I; round that.
+# Bermuda dockyard, Ireland I.  This agrees with standard offset given in the
+# Daylight Saving Act, 1917 cited below.  Round that to the nearest second.
+# It is not known when this time became standard for Bermuda; guess 1890.
+# The transition to -04 was specified by:
+# 1930: The Time Zone Act, 1929 (1929: No. 39) [1929-11-08]
+# https://books.google.com/books?id=7tdMAQAAIAAJ&pg=RA54-PP1
+
+# From P Chan (2020-11-20):
+# Most of the information can be found online from the Bermuda National
+# Library - Digital Collection which includes The Royal Gazette (RG) until 1957
+# https://bnl.contentdm.oclc.org/digital/
+# I will cite the ID.  For example, [10000] means
+# https://bnl.contentdm.oclc.org/digital/collection/BermudaNP02/id/10000
+#
+# 1917: Apr 5 midnight to Sep 30 midnight
+# Daylight Saving Act, 1917 (1917 No. 13) [1917-04-02]
+# Bermuda Acts and Resolves 1917, p 37-38
+# https://books.google.com/books?id=M-lCAQAAMAAJ&pg=PA36-IA2
+# RG, 1917-04-04, p 6 [42340] gives the spring forward date.
+#
+# 1918: Apr 13 midnight to Sep 15 midnight
+# Daylight Saving Act, 1918 (1918 No. 9) [1918-04-06]
+# Bermuda Acts and Resolves 1917, p 13
+# https://books.google.com/books?id=K-lCAQAAMAAJ&pg=RA1-PA7
+#
+# Note that local mean time was still used before 1930.
+#
+# During WWII, DST was introduced by Defence Regulations
+# 1942: Jan 11 02:00 to Oct 18 02:00 [113646], [115726]
+# 1943: Mar 21 02:00 to Oct 31 02:00 [116704], [118193]
+# 1944: Mar 12 02:00 to Nov 5 02:00 [119225], [121593]
+# 1945: Mar 11 02:00 to Nov 4 02:00 [122369], [124461]
+# RG, 1942-01-08, p 2, 1942-10-12, p 2 , 1943-03-06, p 2, 1943-09-03, p 1,
+# 1944-02-29, p 6, 1944-09-20, p 2, 1945-02-13, p 2, 1945-11-03, p 1
+#
+# In 1946, the House of Assembly rejected DST twice. [128686], [128076]
+# RG, 1946-03-16 p 1,1946-04-13 p 1
+#
+# 1947: third Sunday in May 02:00 to second Sunday in September 02:00
+# DST in 1947 was defined in the Daylight Saving Act, 1947 (1947: No. 12)
+# which expired at the end of the year.  [125784] ,[132405], [144454], [138226]
+# RG, 1947-02-27, p 1, 1947-05-15, p 1, 1947-09-13, p 1, 1947-12-30, p 1
+#
+# 1948-1952: fourth Sunday in May 02:00 to first Sunday in September 02:00
+# DST in 1948 was defined in the Daylight Saving Act, 1948 (1948 : No. 12)
+# which was set to expired at the end of the year but it was extended until
+# the end of 1952 and was not further extended.
+# [129802], [139403], [146008], [135240], [144330], [139049], [143309],
+# [148271], [149773], [153589], [153802], [155924]
+# RG, 1948-04-13, p 1, 1948-05-22, p 1, 1948-09-04, p 1, 1949-05-21, p1,
+# 1949-09-03, p 1, 1950-05-27 p 1, 1950-09-02, p 1, 1951-05-27, p 1,
+# 1951-09-01, p 1, 1952-05-23, p 1, 1952-09-26, p 1, 1952-12-21, p 8
+#
+# In 1953-1955, the House of Assembly rejected DST each year. [158996],
+# [162620], [166720] RG, 1953-05-02, p 1, 1954-04-01 p 1, 1955-03-12, p 1
+#
+# 1956: fourth Sunday in May 02:00 to last Sunday in October 02:00
+# Time Zone (Seasonal Variation) Act, 1956 (1956: No.44) [1956-05-25]
+# Bermuda Public Acts 1956, p 331-332
+# https://books.google.com/books?id=Xs1AlmD_cEwC&pg=PA63
+#
+# The extension of the Act was rejected by the House of Assembly. [176218]
+# RG, 1956-12-13, p 1
+#
+# From the Chronological Table of Public and Private Acts up to 1985, it seems
+# that there does not exist other Acts related to DST before 1973.
+# https://books.google.com/books?id=r9hMAQAAIAAJ&pg=RA23-PA1
+# Public Acts of the Legislature of the Islands of Bermuda, Together with
+# Statutory Instruments in Force Thereunder, Vol VII
 
 # From Dan Jones, reporting in The Royal Gazette (2006-06-26):
-
 # Next year, however, clocks in the US will go forward on the second Sunday
 # in March, until the first Sunday in November.  And, after the Time Zone
 # (Seasonal Variation) Bill 2006 was passed in the House of Assembly on
 # Friday, the same thing will happen in Bermuda.
 # http://www.theroyalgazette.com/apps/pbcs.dll/article?AID=/20060529/NEWS/105290135
 
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
+Rule	Bermuda	1917	only	-	Apr	 5	24:00	1:00	-
+Rule	Bermuda	1917	only	-	Sep	30	24:00	0	-
+Rule	Bermuda	1918	only	-	Apr	13	24:00	1:00	-
+Rule	Bermuda	1918	only	-	Sep	15	24:00	0	S
+Rule	Bermuda	1942	only	-	Jan	11	 2:00	1:00	D
+Rule	Bermuda	1942	only	-	Oct	18	 2:00	0	S
+Rule	Bermuda	1943	only	-	Mar	21	 2:00	1:00	D
+Rule	Bermuda	1943	only	-	Oct	31	 2:00	0	S
+Rule	Bermuda	1944	1945	-	Mar	Sun>=8	 2:00	1:00	D
+Rule	Bermuda	1944	1945	-	Nov	Sun>=1	 2:00	0	S
+Rule	Bermuda	1947	only	-	May	Sun>=15	 2:00	1:00	D
+Rule	Bermuda	1947	only	-	Sep	Sun>=8	 2:00	0	S
+Rule	Bermuda	1948	1952	-	May	Sun>=22	 2:00	1:00	D
+Rule	Bermuda	1948	1952	-	Sep	Sun>=1	 2:00	0	S
+Rule	Bermuda	1956	only	-	May	Sun>=22	 2:00	1:00	D
+Rule	Bermuda	1956	only	-	Oct	lastSun	 2:00	0	S
+
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
-Zone Atlantic/Bermuda	-4:19:18 -	LMT	1930 Jan  1  2:00 # Hamilton
-			-4:00	-	AST	1974 Apr 28  2:00
+Zone Atlantic/Bermuda	-4:19:18 -	LMT	1890	# Hamilton
+			-4:19:18 Bermuda BMT/BST 1930 Jan 1  2:00
+			-4:00	Bermuda	A%sT	1974 Apr 28  2:00
 			-4:00	Canada	A%sT	1976
 			-4:00	US	A%sT
 
@@ -3597,7 +3750,7 @@ Zone America/Miquelon	-3:44:40 -	LMT	1911 May 15 # St Pierre
 # "Eastern Standard Times Begins 2007
 # Clocks are set back one hour at 2:00 a.m. local Daylight Saving Time"
 # indicating that the normal ET rules are followed.
-#
+
 # From Paul Eggert (2014-08-19):
 # The 2014-08-13 Cabinet meeting decided to stay on UT -04 year-round.  See:
 # http://tcweeklynews.com/daylight-savings-time-to-be-maintained-p5353-127.htm
@@ -3612,19 +3765,42 @@ Zone America/Miquelon	-3:44:40 -	LMT	1911 May 15 # St Pierre
 # during the summer months and Standard Time, also known as Local
 # Time, during the winter months with effect from April 2018 ...
 # https://www.gov.uk/government/news/turks-and-caicos-post-cabinet-meeting-statement--3
-#
 # From Paul Eggert (2017-08-26):
 # The date of effect of the spring 2018 change appears to be March 11,
 # which makes more sense.  See: Hamilton D. Time change back
 # by March 2018 for TCI. Magnetic Media. 2017-08-25.
 # http://magneticmediatv.com/2017/08/time-change-back-by-march-2018-for-tci/
 #
+# From P Chan (2020-11-27):
+# Standard Time Declaration Order 2015 (L.N. 15/2015)
+# http://online.fliphtml5.com/fizd/czin/#p=2
+#
+# Standard Time Declaration Order 2017 (L.N. 31/2017)
+# http://online.fliphtml5.com/fizd/dmcu/#p=2
+#
+# From Tim Parenti (2020-12-05):
+# Although L.N. 31/2017 reads that it "shall come into operation at 2:00 a.m.
+# on 11th March 2018", a precise interpretation here poses some problems.  The
+# order states that "the standard time to be observed throughout the Turks and
+# Caicos Islands shall be the same time zone as the Eastern United States of
+# America" and further clarifies "[f]or the avoidance of doubt" that it
+# "applies to the Eastern Standard Time as well as any changes thereto for
+# Daylight Saving Time."  However, as clocks in Turks and Caicos approached
+# 02:00 -04, and thus the declared implementation time, it was still 01:00 EST
+# (-05), as DST in the Eastern US would not start until an hour later.
+#
+# Since it is unlikely that those on the islands switched their clocks twice in
+# the span of an hour, we assume instead that the adoption of EDT actually took
+# effect once clocks in the Eastern US had sprung forward, from 03:00 -04.
+# This discrepancy only affects the time zone abbreviation and DST flag for the
+# intervening hour, not wall clock times, as -04 was maintained throughout.
+
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone America/Grand_Turk	-4:44:32 -	LMT	1890
 			-5:07:10 -	KMT	1912 Feb # Kingston Mean Time
 			-5:00	-	EST	1979
-			-5:00	US	E%sT	2015 Nov Sun>=1 2:00
-			-4:00	-	AST	2018 Mar 11 3:00
+			-5:00	US	E%sT	2015 Mar  8  2:00
+			-4:00	-	AST	2018 Mar 11  3:00
 			-5:00	US	E%sT
 
 # British Virgin Is

--- a/make/data/tzdata/zone.tab
+++ b/make/data/tzdata/zone.tab
@@ -79,8 +79,7 @@ AS	-1416-17042	Pacific/Pago_Pago
 AT	+4813+01620	Europe/Vienna
 AU	-3133+15905	Australia/Lord_Howe	Lord Howe Island
 AU	-5430+15857	Antarctica/Macquarie	Macquarie Island
-AU	-4253+14719	Australia/Hobart	Tasmania (most areas)
-AU	-3956+14352	Australia/Currie	Tasmania (King Island)
+AU	-4253+14719	Australia/Hobart	Tasmania
 AU	-3749+14458	Australia/Melbourne	Victoria
 AU	-3352+15113	Australia/Sydney	New South Wales (most areas)
 AU	-3157+14127	Australia/Broken_Hill	New South Wales (Yancowinna)
@@ -153,9 +152,9 @@ CA	+682059-1334300	America/Inuvik	Mountain - NT (west)
 CA	+4906-11631	America/Creston	MST - BC (Creston)
 CA	+5946-12014	America/Dawson_Creek	MST - BC (Dawson Cr, Ft St John)
 CA	+5848-12242	America/Fort_Nelson	MST - BC (Ft Nelson)
+CA	+6043-13503	America/Whitehorse	MST - Yukon (east)
+CA	+6404-13925	America/Dawson	MST - Yukon (west)
 CA	+4916-12307	America/Vancouver	Pacific - BC (most areas)
-CA	+6043-13503	America/Whitehorse	Pacific - Yukon (east)
-CA	+6404-13925	America/Dawson	Pacific - Yukon (west)
 CC	-1210+09655	Indian/Cocos
 CD	-0418+01518	Africa/Kinshasa	Dem. Rep. of Congo (west)
 CD	-1140+02728	Africa/Lubumbashi	Dem. Rep. of Congo (east)
@@ -360,8 +359,8 @@ RU	+554521+0373704	Europe/Moscow	MSK+00 - Moscow area
 # Programs should use zone1970.tab instead; see above.
 UA	+4457+03406	Europe/Simferopol	Crimea
 RU	+5836+04939	Europe/Kirov	MSK+00 - Kirov
+RU	+4844+04425	Europe/Volgograd	MSK+00 - Volgograd
 RU	+4621+04803	Europe/Astrakhan	MSK+01 - Astrakhan
-RU	+4844+04425	Europe/Volgograd	MSK+01 - Volgograd
 RU	+5134+04602	Europe/Saratov	MSK+01 - Saratov
 RU	+5420+04824	Europe/Ulyanovsk	MSK+01 - Ulyanovsk
 RU	+5312+05009	Europe/Samara	MSK+01 - Samara, Udmurtia


### PR DESCRIPTION
Looking to backport the tzdata2020f changes to jdk16-updates. Changes have passed regression.

JBS: https://bugs.openjdk.java.net/browse/JDK-8259048

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8259048](https://bugs.openjdk.java.net/browse/JDK-8259048): (tz) Upgrade time-zone data to tzdata2020f


### Download
`$ git fetch https://git.openjdk.java.net/jdk16u pull/5/head:pull/5`
`$ git checkout pull/5`
