### PR TITLE
8259576: Misplaced curly brace in Matcher::find_shared_post_visit

### DIFF
--- a/src/hotspot/share/opto/matcher.cpp
+++ b/src/hotspot/share/opto/matcher.cpp
@@ -2405,9 +2405,9 @@ void Matcher::find_shared_post_visit(Node* n, uint opcode) {
       n->set_req(2, n->in(3));
       n->del_req(3);
       break;
+    }
     default:
       break;
-    }
   }
 }
 


### PR DESCRIPTION
Backport of [JDK-8259576](https://bugs.openjdk.java.net/browse/JDK-8259576). Applies cleanly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259576](https://bugs.openjdk.java.net/browse/JDK-8259576): Misplaced curly brace in Matcher::find_shared_post_visit


### Reviewers
 * [Vladimir Ivanov](https://openjdk.java.net/census#vlivanov) (@iwanowww - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk16u pull/11/head:pull/11`
`$ git checkout pull/11`
