### PR TITLE
8259777: Incorrect predication condition generated by ADLC

### DIFF
--- a/src/hotspot/share/adlc/formssel.cpp
+++ b/src/hotspot/share/adlc/formssel.cpp
@@ -1520,6 +1520,7 @@ Predicate *InstructForm::build_predicate() {
   for( DictI i(&names); i.test(); ++i ) {
     uintptr_t cnt = (uintptr_t)i._value;
     if( cnt > 1 ) {             // Need a predicate at all?
+      int path_bitmask = 0;
       assert( cnt == 2, "Unimplemented" );
       // Handle many pairs
       if( first ) first=0;
@@ -1530,10 +1531,10 @@ Predicate *InstructForm::build_predicate() {
       // Add predicate to working buffer
       sprintf(s,"/*%s*/(",(char*)i._key);
       s += strlen(s);
-      mnode->build_instr_pred(s,(char*)i._key,0);
+      mnode->build_instr_pred(s,(char*)i._key, 0, path_bitmask, 0);
       s += strlen(s);
       strcpy(s," == "); s += strlen(s);
-      mnode->build_instr_pred(s,(char*)i._key,1);
+      mnode->build_instr_pred(s,(char*)i._key, 1, path_bitmask, 0);
       s += strlen(s);
       strcpy(s,")"); s += strlen(s);
     }
@@ -3417,21 +3418,35 @@ void MatchNode::count_instr_names( Dict &names ) {
 //------------------------------build_instr_pred-------------------------------
 // Build a path to 'name' in buf.  Actually only build if cnt is zero, so we
 // can skip some leading instances of 'name'.
-int MatchNode::build_instr_pred( char *buf, const char *name, int cnt ) {
+int MatchNode::build_instr_pred( char *buf, const char *name, int cnt, int path_bitmask, int level) {
   if( _lChild ) {
-    if( !cnt ) strcpy( buf, "_kids[0]->" );
-    cnt = _lChild->build_instr_pred( buf+strlen(buf), name, cnt );
-    if( cnt < 0 ) return cnt;   // Found it, all done
+    cnt = _lChild->build_instr_pred(buf, name, cnt, path_bitmask, level+1);
+    if( cnt < 0 ) {
+      return cnt;   // Found it, all done
+    }
   }
   if( _rChild ) {
-    if( !cnt ) strcpy( buf, "_kids[1]->" );
-    cnt = _rChild->build_instr_pred( buf+strlen(buf), name, cnt );
-    if( cnt < 0 ) return cnt;   // Found it, all done
+    path_bitmask |= 1 << level;
+    cnt = _rChild->build_instr_pred( buf, name, cnt, path_bitmask, level+1);
+    if( cnt < 0 ) {
+      return cnt;   // Found it, all done
+    }
   }
   if( !_lChild && !_rChild ) {  // Found a leaf
     // Wrong name?  Give up...
     if( strcmp(name,_name) ) return cnt;
-    if( !cnt ) strcpy(buf,"_leaf");
+    if( !cnt )  {
+      for(int i = 0; i < level; i++) {
+        int kid = path_bitmask &  (1 << i);
+        if (0 == kid) {
+          strcpy( buf, "_kids[0]->" );
+        } else {
+          strcpy( buf, "_kids[1]->" );
+        }
+        buf += 10;
+      }
+      strcpy( buf, "_leaf" );
+    }
     return cnt-1;
   }
   return cnt;

--- a/src/hotspot/share/adlc/formssel.hpp
+++ b/src/hotspot/share/adlc/formssel.hpp
@@ -969,7 +969,7 @@ public:
 
   // Help build instruction predicates.  Search for operand names.
   void count_instr_names( Dict &names );
-  int build_instr_pred( char *buf, const char *name, int cnt );
+  int build_instr_pred( char *buf, const char *name, int cnt, int path_bitmask, int level);
   void build_internalop( );
 
   // Return the name of the operands associated with reducing to this operand:


### PR DESCRIPTION
Backport of [JDK-8259777](https://bugs.openjdk.java.net/browse/JDK-8259777). Applies cleanly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259777](https://bugs.openjdk.java.net/browse/JDK-8259777): Incorrect predication condition generated by ADLC


### Reviewers
 * [Vladimir Ivanov](https://openjdk.java.net/census#vlivanov) (@iwanowww - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk16u pull/14/head:pull/14`
`$ git checkout pull/14`
