### PR TITLE
8260338: Some fields in HaltNode is not cloned

### DIFF
--- a/src/hotspot/share/opto/rootnode.cpp
+++ b/src/hotspot/share/opto/rootnode.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -74,6 +74,7 @@ HaltNode::HaltNode(Node* ctrl, Node* frameptr, const char* halt_reason, bool rea
 }
 
 const Type *HaltNode::bottom_type() const { return Type::BOTTOM; }
+uint HaltNode::size_of() const { return sizeof(*this); }
 
 //------------------------------Ideal------------------------------------------
 Node *HaltNode::Ideal(PhaseGVN *phase, bool can_reshape) {

--- a/src/hotspot/share/opto/rootnode.hpp
+++ b/src/hotspot/share/opto/rootnode.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,6 +50,8 @@ public:
 //------------------------------HaltNode---------------------------------------
 // Throw an exception & die
 class HaltNode : public Node {
+protected:
+  virtual uint size_of() const;
 public:
   const char* _halt_reason;
   bool        _reachable;


### PR DESCRIPTION
Backport of [JDK-8260338](https://bugs.openjdk.java.net/browse/JDK-8260338). Applies cleanly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260338](https://bugs.openjdk.java.net/browse/JDK-8260338): Some fields in HaltNode is not cloned


### Reviewers
 * [Vladimir Ivanov](https://openjdk.java.net/census#vlivanov) (@iwanowww - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk16u pull/15/head:pull/15`
`$ git checkout pull/15`
