### PR TITLE
8260864: ProblemList two security/krb5 tests on Linux

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -701,6 +701,8 @@ javax/security/auth/kerberos/KerberosTixDateTest.java           8039280 generic-
 sun/security/provider/PolicyFile/GrantAllPermToExtWhenNoPolicy.java 8039280 generic-all
 sun/security/provider/PolicyParser/ExtDirsChange.java           8039280 generic-all
 sun/security/provider/PolicyParser/PrincipalExpansionError.java 8039280 generic-all
+sun/security/krb5/auto/ReplayCacheTestProcWithMD5.java          8258855 linux-all
+sun/security/krb5/auto/ReplayCacheTestProc.java                 8258855 linux-all
 
 ############################################################################
 


### PR DESCRIPTION
Reviewed-by: dholmes

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8260864](https://bugs.openjdk.java.net/browse/JDK-8260864): ProblemList two security/krb5 tests on Linux


### Reviewers
 * [Mikael Vidstedt](https://openjdk.java.net/census#mikael) (@vidmik - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/jdk16u pull/21/head:pull/21`
`$ git checkout pull/21`
