### PR TITLE
8261310: PPC64 Zero build fails with 'VMError::controlled_crash(int)::FunctionDescriptor functionDescriptor' has incomplete type and cannot be defined

### DIFF
--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -1795,7 +1795,7 @@ void VMError::controlled_crash(int how) {
   char * const dataPtr = NULL;  // bad data pointer
   const void (*funcPtr)(void);  // bad function pointer
 
-#if defined(PPC64) && !defined(ABI_ELFv2)
+#if defined(PPC64) && !defined(ABI_ELFv2) && !defined(ZERO)
   struct FunctionDescriptor functionDescriptor;
 
   functionDescriptor.set_entry((address) 0xF);


### PR DESCRIPTION
Note this is **not** a backport, but 16u-specific change.

```
$ CONF=linux-ppc64-zero-fastdebug make hotspot

/home/shade/trunks/jdk16/src/hotspot/share/utilities/vmError.cpp: In static member function 'static void VMError::controlled_crash(int)':
/home/shade/trunks/jdk16/src/hotspot/share/utilities/vmError.cpp:1799:29: error: aggregate 'VMError::controlled_crash(int)::FunctionDescriptor functionDescriptor' has incomplete type and cannot be defined
 1799 | struct FunctionDescriptor functionDescriptor;
      | ^~~~~~~~~~~~~~~~~~
```

`FunctionDescriptor` is from `src/hotspot/cpu/ppc/assembler_ppc.hpp`, and obviously not available for Zero.

The affected code was removed by JDK-8252148 in 17, so this issue affects versions below it.
While not exactly the regression for 16, it would be nice to have this fixed for 16 and lower, to get clean builds on all platform configurations, including JDK 16 GA.

The fix is trivial:

```
diff --git a/src/hotspot/share/utilities/vmError.cpp b/src/hotspot/share/utilities/vmError.cpp
index 9b0dc413bcd..476fdc48e43 100644
--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -1795,7 +1795,7 @@ void VMError::controlled_crash(int how) {
   char * const dataPtr = NULL; // bad data pointer
   const void (*funcPtr)(void); // bad function pointer
 
-#if defined(PPC64) && !defined(ABI_ELFv2)
+#if defined(PPC64) && !defined(ABI_ELFv2) && !defined(ZERO)
   struct FunctionDescriptor functionDescriptor;
 
   functionDescriptor.set_entry((address) 0xF);
```

Additional testing:
 - [x] Linux Zero PPC64 fastdebug build

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261310](https://bugs.openjdk.java.net/browse/JDK-8261310): PPC64 Zero build fails with 'VMError::controlled_crash(int)::FunctionDescriptor functionDescriptor' has incomplete type and cannot be defined


### Reviewers
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk16u pull/23/head:pull/23`
`$ git checkout pull/23`
