### PR TITLE
8259628: jdk/net/ExtendedSocketOption/AsynchronousSocketChannelNAPITest.java fails intermittently

### DIFF
--- a/test/jdk/jdk/net/ExtendedSocketOption/AsynchronousSocketChannelNAPITest.java
+++ b/test/jdk/jdk/net/ExtendedSocketOption/AsynchronousSocketChannelNAPITest.java
@@ -95,7 +95,7 @@ public class AsynchronousSocketChannelNAPITest {
 
     @Test
     public void testSocketChannel() throws Exception {
-        int socketID, clientID, tempID = 0;
+        int socketID, clientID, originalClientID = 0;
         boolean initialRun = true;
         try (var ss = AsynchronousServerSocketChannel.open()) {
             ss.bind(new InetSocketAddress(hostAddr, 0));
@@ -108,20 +108,21 @@ public class AsynchronousSocketChannelNAPITest {
 
                     for (int i = 0; i < 10; i++) {
                         s.write(ByteBuffer.wrap("test".getBytes()));
+
                         socketID = s.getOption(SO_INCOMING_NAPI_ID);
                         assertEquals(socketID, 0, "AsynchronousSocketChannel: Sender");
 
-                        c.read(ByteBuffer.allocate(128));
+                        c.read(ByteBuffer.allocate(128)).get();
                         clientID = ss.getOption(SO_INCOMING_NAPI_ID);
 
                         // check ID remains consistent
                         if (initialRun) {
                             assertTrue(clientID >= 0, "AsynchronousSocketChannel: Receiver");
-                        } else {
-                            assertEquals(clientID, tempID);
                             initialRun = false;
+                            originalClientID = clientID;
+                        } else {
+                            assertEquals(clientID, originalClientID);
                         }
-                        tempID = clientID;
                     }
                 }
             }


### PR DESCRIPTION
This is a direct backport of

8259628: jdk/net/ExtendedSocketOption/AsynchronousSocketChannelNAPITest.java fails intermittently

The patch applies clean, and the test passes on all platforms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8259628](https://bugs.openjdk.java.net/browse/JDK-8259628): jdk/net/ExtendedSocketOption/AsynchronousSocketChannelNAPITest.java fails intermittently


### Download
`$ git fetch https://git.openjdk.java.net/jdk16u pull/27/head:pull/27`
`$ git checkout pull/27`
