### PR TITLE
8261261: The version extra fields needs to be overridable in jib-profiles.js

### DIFF
--- a/make/conf/jib-profiles.js
+++ b/make/conf/jib-profiles.js
@@ -1362,15 +1362,15 @@ var concatObjects = function (o1, o2) {
  * @param patch Override patch version
  * @returns {String} The numeric version string
  */
-var getVersion = function (feature, interim, update, patch) {
+var getVersion = function (feature, interim, update, patch, extra1, extra2, extra3) {
     var version_numbers = getVersionNumbers();
     var version = (feature != null ? feature : version_numbers.get("DEFAULT_VERSION_FEATURE"))
         + "." + (interim != null ? interim : version_numbers.get("DEFAULT_VERSION_INTERIM"))
         + "." + (update != null ? update :  version_numbers.get("DEFAULT_VERSION_UPDATE"))
         + "." + (patch != null ? patch : version_numbers.get("DEFAULT_VERSION_PATCH"))
-        + "." + version_numbers.get("DEFAULT_VERSION_EXTRA1")
-        + "." + version_numbers.get("DEFAULT_VERSION_EXTRA2")
-        + "." + version_numbers.get("DEFAULT_VERSION_EXTRA3");
+        + "." + (extra1 != null ? extra1 : version_numbers.get("DEFAULT_VERSION_EXTRA1"))
+        + "." + (extra2 != null ? extra2 : version_numbers.get("DEFAULT_VERSION_EXTRA2"))
+        + "." + (extra3 != null ? extra3 : version_numbers.get("DEFAULT_VERSION_EXTRA3"));
     while (version.match(".*\\.0$")) {
         version = version.substring(0, version.length - 2);
     }


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8261261](https://bugs.openjdk.java.net/browse/JDK-8261261): The version extra fields needs to be overridable in jib-profiles.js


### Reviewers
 * [Mikael Vidstedt](https://openjdk.java.net/census#mikael) (@vidmik - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/jdk16u pull/30/head:pull/30`
`$ git checkout pull/30`
