### PR TITLE
8261758: [TESTBUG] gc/g1/TestGCLogMessages.java fails if ergonomics detect too small InitialHeapSize

### DIFF
--- a/test/hotspot/jtreg/gc/g1/TestGCLogMessages.java
+++ b/test/hotspot/jtreg/gc/g1/TestGCLogMessages.java
@@ -260,6 +260,7 @@ public class TestGCLogMessages {
         pb = ProcessTools.createJavaProcessBuilder("-XX:+UseG1GC",
                                                    "-Xmx32M",
                                                    "-Xmn16M",
+                                                   "-Xms32M",
                                                    "-Xlog:gc+phases=trace",
                                                    GCTestWithEvacuationFailure.class.getName());
 


### PR DESCRIPTION
Patch applies cleanly and fixes the test in 16u. Risk should be minimal, as only a test case is changed. Without this backport, we are not able to run the hotspot tier1 JTreg test suite for aarch32 on memory constrained devices.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8261758](https://bugs.openjdk.java.net/browse/JDK-8261758): [TESTBUG] gc/g1/TestGCLogMessages.java fails if ergonomics detect too small InitialHeapSize ⚠️ Issue is not open.


### Download
`$ git fetch https://git.openjdk.java.net/jdk16u pull/31/head:pull/31`
`$ git checkout pull/31`
