### PR TITLE
8262018: Wrong format in SAP copyright header of OsVersionTest

### DIFF
--- a/test/jdk/java/lang/System/OsVersionTest.java
+++ b/test/jdk/java/lang/System/OsVersionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, SAP SE. All rights reserved.
+ * Copyright (c) 2015, 2021 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
Wrong format in SAP copyright header of OsVersionTest

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8262018](https://bugs.openjdk.java.net/browse/JDK-8262018): Wrong format in SAP copyright header of OsVersionTest


### Download
`$ git fetch https://git.openjdk.java.net/jdk16u pull/37/head:pull/37`
`$ git checkout pull/37`
