### PR TITLE
8261334: NMT: tuning statistic shows incorrect hash distribution

### DIFF
--- a/src/hotspot/share/services/memTracker.cpp
+++ b/src/hotspot/share/services/memTracker.cpp
@@ -260,7 +260,7 @@ class StatisticsWalker : public MallocSiteWalker {
     _stack_depth_distribution[frames - 1] ++;
 
     // hash distribution
-    int hash_bucket = e->hash() % MallocSiteTable::hash_buckets();
+    int hash_bucket = ((unsigned)e->hash()) % MallocSiteTable::hash_buckets();
     if (_current_hash_bucket == -1) {
       _current_hash_bucket = hash_bucket;
       _current_bucket_length = 1;


### PR DESCRIPTION
The original bug fix patch applied cleanly. After applying the patch to a JDK-16u repo, the fix was regression tested by running Mach5 tiers 1 and 2 on Linux, Windows, and Mac OS, and running tiers 3-5 on Linux x64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8261334](https://bugs.openjdk.java.net/browse/JDK-8261334): NMT: tuning statistic shows incorrect hash distribution


### Download
`$ git fetch https://git.openjdk.java.net/jdk16u pull/42/head:pull/42`
`$ git checkout pull/42`
