### PR TITLE
8259954: gc/shenandoah/mxbeans tests fail with -Xcomp

### DIFF
--- a/test/hotspot/jtreg/gc/shenandoah/mxbeans/TestChurnNotifications.java
+++ b/test/hotspot/jtreg/gc/shenandoah/mxbeans/TestChurnNotifications.java
@@ -159,7 +159,12 @@ public class TestChurnNotifications {
 
         System.gc();
 
-        Thread.sleep(1000);
+        // Wait until notifications start arriving, and then wait some more
+        // to catch the ones arriving late.
+        while (churnBytes.get() == 0) {
+            Thread.sleep(1000);
+        }
+        Thread.sleep(5000);
 
         long actual = churnBytes.get();
 

--- a/test/hotspot/jtreg/gc/shenandoah/mxbeans/TestPauseNotifications.java
+++ b/test/hotspot/jtreg/gc/shenandoah/mxbeans/TestPauseNotifications.java
@@ -148,7 +148,12 @@ public class TestPauseNotifications {
             sink = new int[size];
         }
 
-        Thread.sleep(1000);
+        // Wait until notifications start arriving, and then wait some more
+        // to catch the ones arriving late.
+        while (pausesDuration.get() == 0) {
+            Thread.sleep(1000);
+        }
+        Thread.sleep(5000);
 
         long pausesActual = pausesDuration.get();
         long cyclesActual = cyclesDuration.get();


### PR DESCRIPTION
This improves Shenandoah tests reliability. Affected tests fail with -Xcomp before the patch, and pass after.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8259954](https://bugs.openjdk.java.net/browse/JDK-8259954): gc/shenandoah/mxbeans tests fail with -Xcomp


### Download
`$ git fetch https://git.openjdk.java.net/jdk16u pull/49/head:pull/49`
`$ git checkout pull/49`
