### PR TITLE
8251944: Add Shenandoah test config to compiler/gcbarriers/UnsafeIntrinsicsTest.java

### DIFF
--- a/test/hotspot/jtreg/compiler/gcbarriers/UnsafeIntrinsicsTest.java
+++ b/test/hotspot/jtreg/compiler/gcbarriers/UnsafeIntrinsicsTest.java
@@ -22,14 +22,36 @@
  */
 
 /*
- * @test
+ * @test id=z
  * @key randomness
  * @bug 8059022
  * @modules java.base/jdk.internal.misc:+open
  * @summary Validate barriers after Unsafe getReference, CAS and swap (GetAndSet)
  * @requires vm.gc.Z
  * @library /test/lib
- * @run main/othervm -XX:+UseZGC -XX:+UnlockDiagnosticVMOptions -XX:+ZVerifyViews -XX:ZCollectionInterval=1 -XX:-CreateCoredumpOnCrash -XX:CompileCommand=dontinline,*::mergeImpl* compiler.gcbarriers.UnsafeIntrinsicsTest
+ * @run main/othervm -XX:+UseZGC
+ *                   -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:+ZVerifyViews -XX:ZCollectionInterval=1
+ *                   -XX:-CreateCoredumpOnCrash
+ *                   -XX:CompileCommand=dontinline,*::mergeImpl*
+ *                   compiler.gcbarriers.UnsafeIntrinsicsTest
+ */
+
+/*
+ * @test id=shenandoah
+ * @key randomness
+ * @bug 8255401 8251944
+ * @modules java.base/jdk.internal.misc:+open
+ * @summary Validate barriers after Unsafe getReference, CAS and swap (GetAndSet)
+ * @requires vm.gc.Shenandoah
+ * @library /test/lib
+ * @run main/othervm -XX:+UseShenandoahGC
+ *                   -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:-CreateCoredumpOnCrash
+ *                   -XX:+ShenandoahVerify
+ *                   -XX:+IgnoreUnrecognizedVMOptions -XX:+ShenandoahVerifyOptoBarriers
+ *                   -XX:CompileCommand=dontinline,*::mergeImpl*
+ *                   compiler.gcbarriers.UnsafeIntrinsicsTest
  */
 
 package compiler.gcbarriers;


### PR DESCRIPTION
This improves coverage for Shenandoah. This test fails without JDK-8255401 and passes with it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8251944](https://bugs.openjdk.java.net/browse/JDK-8251944): Add Shenandoah test config to compiler/gcbarriers/UnsafeIntrinsicsTest.java


### Download
`$ git fetch https://git.openjdk.java.net/jdk16u pull/50/head:pull/50`
`$ git checkout pull/50`
