### PR TITLE
8261413: Shenandoah: Disable class-unloading in I-U mode

### DIFF
--- a/src/hotspot/share/gc/shenandoah/mode/shenandoahIUMode.cpp
+++ b/src/hotspot/share/gc/shenandoah/mode/shenandoahIUMode.cpp
@@ -35,6 +35,11 @@
 #include "runtime/java.hpp"
 
 void ShenandoahIUMode::initialize_flags() const {
+  if (FLAG_IS_CMDLINE(ClassUnloadingWithConcurrentMark) && ClassUnloading) {
+    log_warning(gc)("Shenandoah I-U mode sets -XX:-ClassUnloadingWithConcurrentMark; see JDK-8261341 for details");
+  }
+  FLAG_SET_DEFAULT(ClassUnloadingWithConcurrentMark, false);
+
   if (ShenandoahConcurrentRoots::can_do_concurrent_class_unloading()) {
     FLAG_SET_DEFAULT(ShenandoahSuspendibleWorkers, true);
     FLAG_SET_DEFAULT(VerifyBeforeExit, false);


### PR DESCRIPTION
This workarounds the bug in non-default Shenandoah mode. The risk is low, as it only affects Shenandoah code.

Additional testing:
 - [x] hotspot_gc_shenandoah

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261413](https://bugs.openjdk.java.net/browse/JDK-8261413): Shenandoah: Disable class-unloading in I-U mode


### Reviewers
 * [Zhengyu Gu](https://openjdk.java.net/census#zgu) (@zhengyu123 - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk16u pull/54/head:pull/54`
`$ git checkout pull/54`
