### PR TITLE
8261251: Shenandoah: Use object size for full GC humongous compaction

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahMarkCompact.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahMarkCompact.cpp
@@ -915,7 +915,7 @@ void ShenandoahMarkCompact::compact_humongous_objects() {
 
       Copy::aligned_conjoint_words(heap->get_region(old_start)->bottom(),
                                    heap->get_region(new_start)->bottom(),
-                                   ShenandoahHeapRegion::region_size_words()*num_regions);
+                                   words_size);
 
       oop new_obj = oop(heap->get_region(new_start)->bottom());
       new_obj->init_mark();


### PR DESCRIPTION
This fixes a minor performance issue in Shenandoah (which becomes asserted in later projects, i.e. Loom).

Additional testing:
 - [x] hotspot_gc_shenandoah

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261251](https://bugs.openjdk.java.net/browse/JDK-8261251): Shenandoah: Use object size for full GC humongous compaction


### Reviewers
 * [Zhengyu Gu](https://openjdk.java.net/census#zgu) (@zhengyu123 - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk16u pull/55/head:pull/55`
`$ git checkout pull/55`
