### PR TITLE
8252883: AccessDeniedException caused by delayed file deletion on Windows

### DIFF
--- a/src/java.logging/share/classes/java/util/logging/FileHandler.java
+++ b/src/java.logging/share/classes/java/util/logging/FileHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,6 +36,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.channels.FileChannel;
 import java.nio.channels.OverlappingFileLockException;
+import java.nio.file.AccessDeniedException;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
@@ -511,6 +512,22 @@ public class FileHandler extends StreamHandler {
                         channel = FileChannel.open(lockFilePath,
                                 CREATE_NEW, WRITE);
                         fileCreated = true;
+                    } catch (AccessDeniedException ade) {
+                        // This can be either a temporary, or a more permanent issue.
+                        // The lock file might be still pending deletion from a previous run
+                        // (temporary), or the parent directory might not be accessible,
+                        // not writable, etc..
+                        // If we can write to the current directory, and this is a regular file,
+                        // let's try again.
+                        if (Files.isRegularFile(lockFilePath, LinkOption.NOFOLLOW_LINKS)
+                            && isParentWritable(lockFilePath)) {
+                            // Try again. If it doesn't work, then this will
+                            // eventually ensure that we increment "unique" and
+                            // use another file name.
+                            continue;
+                        } else {
+                            throw ade; // no need to retry
+                        }
                     } catch (FileAlreadyExistsException ix) {
                         // This may be a zombie file left over by a previous
                         // execution. Reuse it - but only if we can actually

--- a/test/jdk/java/util/logging/FileHandlerAccessTest.java
+++ b/test/jdk/java/util/logging/FileHandlerAccessTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.util.logging.FileHandler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+
+/**
+ * @test
+ * @bug 8252883
+ * @summary tests the handling of AccessDeniedException due to delay in Windows deletion.
+ * @modules java.logging/java.util.logging:open
+ * @run main/othervm FileHandlerAccessTest 20
+ * @author evwhelan
+ */
+
+public class FileHandlerAccessTest {
+    public static void main(String[] args) {
+        var count = Integer.parseInt(args[0]);
+        System.out.println("Testing with " + count + " threads");
+        for (var i = 0; i < count; i++) {
+            new Thread(FileHandlerAccessTest::access).start();
+        }
+    }
+
+    private static void access() {
+        try {
+            var handler = new FileHandler("sample%g.log", 1048576, 2, true);
+            handler.publish(new LogRecord(Level.SEVERE, "TEST"));
+            handler.close();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8252883](https://bugs.openjdk.java.net/browse/JDK-8252883): AccessDeniedException caused by delayed file deletion on Windows


### Download
`$ git fetch https://git.openjdk.java.net/jdk16u pull/56/head:pull/56`
`$ git checkout pull/56`
