### PR TITLE
8260933: runtime/cds/serviceability/ReplaceCriticalClassesForSubgraphs.java fails without CompactStrings

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/serviceability/ReplaceCriticalClassesForSubgraphs.java
+++ b/test/hotspot/jtreg/runtime/cds/serviceability/ReplaceCriticalClassesForSubgraphs.java
@@ -42,12 +42,12 @@ public class ReplaceCriticalClassesForSubgraphs extends ReplaceCriticalClasses {
         String tests[] = {
             // Try to replace classes that are used by the archived subgraph graphs. (CDS should be disabled)
             "-early -notshared -subgraph java/lang/module/ResolvedModule jdk.internal.module.ArchivedModuleGraph",
-            "-early -notshared -subgraph java/lang/Long java.lang.Long$LongCache",
+            "-early -notshared -subgraph java/lang/Integer java.lang.Integer$IntegerCache",
 
             // CDS should not be disabled -- these critical classes cannot be replaced because
             // JvmtiExport::early_class_hook_env() is false.
             "-subgraph java/lang/module/ResolvedModule jdk.internal.module.ArchivedModuleGraph",
-            "-subgraph java/lang/Long java.lang.Long$LongCache",
+            "-subgraph java/lang/Integer java.lang.Integer$IntegerCache",
 
             // Tests for archived full module graph. We cannot use whitebox, which requires appending to bootclasspath.
             // VM will disable full module graph if bootclasspath is appended.


### PR DESCRIPTION
This stabilizes the test.

Additional testing:
 - [x] Linux x86_64 fastdebug, affected tests with/without `-XX:-CompactStrings`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8260933](https://bugs.openjdk.java.net/browse/JDK-8260933): runtime/cds/serviceability/ReplaceCriticalClassesForSubgraphs.java fails without CompactStrings


### Download
`$ git fetch https://git.openjdk.java.net/jdk16u pull/60/head:pull/60`
`$ git checkout pull/60`
