### PR TITLE
8260934: java/lang/StringBuilder/HugeCapacity.java fails without Compact Strings

### DIFF
--- a/test/jdk/java/lang/StringBuilder/HugeCapacity.java
+++ b/test/jdk/java/lang/StringBuilder/HugeCapacity.java
@@ -27,14 +27,20 @@
  * @summary Capacity should not get close to Integer.MAX_VALUE unless
  *          necessary
  * @requires (sun.arch.data.model == "64" & os.maxMemory >= 6G)
- * @run main/othervm -Xms5G -Xmx5G HugeCapacity
+ * @run main/othervm -Xms5G -Xmx5G -XX:+CompactStrings HugeCapacity true
+ * @run main/othervm -Xms5G -Xmx5G -XX:-CompactStrings HugeCapacity false
  */
 
 public class HugeCapacity {
     private static int failures = 0;
 
     public static void main(String[] args) {
-        testLatin1();
+        if (args.length == 0) {
+           throw new IllegalArgumentException("Need the argument");
+        }
+        boolean isCompact = Boolean.parseBoolean(args[0]);
+
+        testLatin1(isCompact);
         testUtf16();
         testHugeInitialString();
         testHugeInitialCharSequence();
@@ -43,11 +49,12 @@ public class HugeCapacity {
         }
     }
 
-    private static void testLatin1() {
+    private static void testLatin1(boolean isCompact) {
         try {
+            int divisor = isCompact ? 2 : 4;
             StringBuilder sb = new StringBuilder();
-            sb.ensureCapacity(Integer.MAX_VALUE / 2);
-            sb.ensureCapacity(Integer.MAX_VALUE / 2 + 1);
+            sb.ensureCapacity(Integer.MAX_VALUE / divisor);
+            sb.ensureCapacity(Integer.MAX_VALUE / divisor + 1);
         } catch (OutOfMemoryError oom) {
             oom.printStackTrace();
             failures++;


### PR DESCRIPTION
This stabilizes the test.

Additional testing:
 - [x] Linux x86_64 fastdebug, affected test, `-XX:-CompactStrings`
 - [x] Linux x86_64 fastdebug, affected test, `-XX:+CompactStrings`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8260934](https://bugs.openjdk.java.net/browse/JDK-8260934): java/lang/StringBuilder/HugeCapacity.java fails without Compact Strings


### Download
`$ git fetch https://git.openjdk.java.net/jdk16u pull/61/head:pull/61`
`$ git checkout pull/61`
