### PR TITLE
8259451: Zero: skip serviceability/sa tests, set vm.hasSA to false

### DIFF
--- a/test/lib/jdk/test/lib/Platform.java
+++ b/test/lib/jdk/test/lib/Platform.java
@@ -226,6 +226,9 @@ public class Platform {
      * on this platform.
      */
     public static boolean hasSA() {
+        if (isZero()) {
+            return false; // SA is not enabled.
+        }
         if (isAix()) {
             return false; // SA not implemented.
         } else if (isLinux()) {


### PR DESCRIPTION
This cleans up test runs with Zero. 

Additional testing:
 - [x] Linux x86_64 zero, `serviceability/sa` (now skipped)
 - [x] Linux x86_64 server, `serviceability/sa` (still pass)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8259451](https://bugs.openjdk.java.net/browse/JDK-8259451): Zero: skip serviceability/sa tests, set vm.hasSA to false


### Download
`$ git fetch https://git.openjdk.java.net/jdk16u pull/63/head:pull/63`
`$ git checkout pull/63`
