### PR TITLE
8253910: UseCompressedClassPointers depends on UseCompressedOops in vmError.cpp

### DIFF
--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -339,7 +339,7 @@ static void report_vm_version(outputStream* st, char* buf, int buflen) {
                 buf, jdk_debug_level, runtime_version);
 
    // This is the long version with some default settings added
-   st->print_cr("# Java VM: %s%s%s (%s%s, %s%s%s%s%s, %s, %s)",
+   st->print_cr("# Java VM: %s%s%s (%s%s, %s%s%s%s%s%s, %s, %s)",
                  VM_Version::vm_name(),
                 (*vendor_version != '\0') ? " " : "", vendor_version,
                  jdk_debug_level,
@@ -353,6 +353,7 @@ static void report_vm_version(outputStream* st, char* buf, int buflen) {
                  "", "",
 #endif
                  UseCompressedOops ? ", compressed oops" : "",
+                 UseCompressedClassPointers ? ", compressed class ptrs" : "",
                  GCConfig::hs_err_name(),
                  VM_Version::vm_platform_string()
                );
@@ -919,11 +920,15 @@ void VMError::report(outputStream* st, bool _verbose) {
 
      if (_verbose && UseCompressedOops) {
        CompressedOops::print_mode(st);
-       if (UseCompressedClassPointers) {
-         CDS_ONLY(MetaspaceShared::print_on(st);)
-         Metaspace::print_compressed_class_space(st);
-         CompressedKlassPointers::print_mode(st);
-       }
+       st->cr();
+     }
+
+  STEP("printing compressed klass pointers mode")
+
+     if (_verbose && UseCompressedClassPointers) {
+       CDS_ONLY(MetaspaceShared::print_on(st);)
+       Metaspace::print_compressed_class_space(st);
+       CompressedKlassPointers::print_mode(st);
        st->cr();
      }
 #endif
@@ -1130,11 +1135,14 @@ void VMError::print_vm_info(outputStream* st) {
   // STEP("printing compressed oops mode")
   if (UseCompressedOops) {
     CompressedOops::print_mode(st);
-    if (UseCompressedClassPointers) {
-      CDS_ONLY(MetaspaceShared::print_on(st);)
-      Metaspace::print_compressed_class_space(st);
-      CompressedKlassPointers::print_mode(st);
-    }
+    st->cr();
+  }
+
+  // STEP("printing compressed class ptrs mode")
+  if (UseCompressedClassPointers) {
+    CDS_ONLY(MetaspaceShared::print_on(st);)
+    Metaspace::print_compressed_class_space(st);
+    CompressedKlassPointers::print_mode(st);
     st->cr();
   }
 #endif


### PR DESCRIPTION
This improves hs_errs after JDK 16 change, which might be confusing (compress klass ptrs are enabled, when hs_err is pointing out in only one place in heap info). 

Additional testing:
 - [x] Linux x86_64 fastdebug `tier1`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8253910](https://bugs.openjdk.java.net/browse/JDK-8253910): UseCompressedClassPointers depends on UseCompressedOops in vmError.cpp


### Download
`$ git fetch https://git.openjdk.java.net/jdk16u pull/64/head:pull/64`
`$ git checkout pull/64`
