### PR TITLE
8258534: Epsilon: clean up unused includes

### DIFF
--- a/src/hotspot/share/gc/epsilon/epsilonArguments.cpp
+++ b/src/hotspot/share/gc/epsilon/epsilonArguments.cpp
@@ -28,7 +28,6 @@
 #include "gc/shared/gcArguments.hpp"
 #include "runtime/globals.hpp"
 #include "runtime/globals_extension.hpp"
-#include "utilities/macros.hpp"
 
 size_t EpsilonArguments::conservative_max_heap_alignment() {
   return UseLargePages ? os::large_page_size() : os::vm_page_size();

--- a/src/hotspot/share/gc/epsilon/epsilonBarrierSet.cpp
+++ b/src/hotspot/share/gc/epsilon/epsilonBarrierSet.cpp
@@ -28,7 +28,6 @@
 #include "gc/epsilon/epsilonThreadLocalData.hpp"
 #include "gc/shared/barrierSet.hpp"
 #include "gc/shared/barrierSetAssembler.hpp"
-#include "utilities/macros.hpp"
 #ifdef COMPILER1
 #include "gc/shared/c1/barrierSetC1.hpp"
 #endif


### PR DESCRIPTION
This simplifies the build and keeps codebases in sync.

Additional testing:
 - [x] Linux x86_64 fastdebug `gc/epsilon`
 - [x] Linux x86_64 release `gc/epsilon`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8258534](https://bugs.openjdk.java.net/browse/JDK-8258534): Epsilon: clean up unused includes


### Download
`$ git fetch https://git.openjdk.java.net/jdk16u pull/65/head:pull/65`
`$ git checkout pull/65`
