### PR TITLE
8259231: Epsilon: improve performance under contention during virtual space expansion

### DIFF
--- a/src/hotspot/share/gc/epsilon/epsilonHeap.cpp
+++ b/src/hotspot/share/gc/epsilon/epsilonHeap.cpp
@@ -106,31 +106,44 @@ EpsilonHeap* EpsilonHeap::heap() {
 HeapWord* EpsilonHeap::allocate_work(size_t size) {
   assert(is_object_aligned(size), "Allocation size should be aligned: " SIZE_FORMAT, size);
 
-  HeapWord* res = _space->par_allocate(size);
-
-  while (res == NULL) {
-    // Allocation failed, attempt expansion, and retry:
-    MutexLocker ml(Heap_lock);
-
-    size_t space_left = max_capacity() - capacity();
-    size_t want_space = MAX2(size, EpsilonMinHeapExpand);
-
-    if (want_space < space_left) {
-      // Enough space to expand in bulk:
-      bool expand = _virtual_space.expand_by(want_space);
-      assert(expand, "Should be able to expand");
-    } else if (size < space_left) {
-      // No space to expand in bulk, and this allocation is still possible,
-      // take all the remaining space:
-      bool expand = _virtual_space.expand_by(space_left);
-      assert(expand, "Should be able to expand");
-    } else {
-      // No space left:
-      return NULL;
+  HeapWord* res = NULL;
+  while (true) {
+    // Try to allocate, assume space is available
+    res = _space->par_allocate(size);
+    if (res != NULL) {
+      break;
     }
 
-    _space->set_end((HeapWord *) _virtual_space.high());
-    res = _space->par_allocate(size);
+    // Allocation failed, attempt expansion, and retry:
+    {
+      MutexLocker ml(Heap_lock);
+
+      // Try to allocate under the lock, assume another thread was able to expand
+      res = _space->par_allocate(size);
+      if (res != NULL) {
+        break;
+      }
+
+      // Expand and loop back if space is available
+      size_t space_left = max_capacity() - capacity();
+      size_t want_space = MAX2(size, EpsilonMinHeapExpand);
+
+      if (want_space < space_left) {
+        // Enough space to expand in bulk:
+        bool expand = _virtual_space.expand_by(want_space);
+        assert(expand, "Should be able to expand");
+      } else if (size < space_left) {
+        // No space to expand in bulk, and this allocation is still possible,
+        // take all the remaining space:
+        bool expand = _virtual_space.expand_by(space_left);
+        assert(expand, "Should be able to expand");
+      } else {
+        // No space left:
+        return NULL;
+      }
+
+      _space->set_end((HeapWord *) _virtual_space.high());
+    }
   }
 
   size_t used = _space->used();


### PR DESCRIPTION
This improves Epsilon performance under heavy contention.

Additional testing:
 - [x] Linux x86_64 fastdebug `gc/epsilon`
 - [x] Linux x86_64 release `gc/epsilon`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8259231](https://bugs.openjdk.java.net/browse/JDK-8259231): Epsilon: improve performance under contention during virtual space expansion


### Download
`$ git fetch https://git.openjdk.java.net/jdk16u pull/66/head:pull/66`
`$ git checkout pull/66`
