### PR TITLE
8260592: jpackage tests fail when Desktop is not supported

### DIFF
--- a/test/jdk/tools/jpackage/apps/image/Hello.java
+++ b/test/jdk/tools/jpackage/apps/image/Hello.java
@@ -154,6 +154,12 @@ public class Hello implements OpenFilesHandler {
 
         trace("Environment supports a display");
 
+        if (!Desktop.isDesktopSupported()) {
+            return null;
+        }
+
+        trace("Environment supports a desktop");
+
         try {
             // Disable JAB.
             // Needed to suppress error:


### PR DESCRIPTION
This unbreaks jpackage tests on x86_32 cross-compiled builds. 

Additional testing:
 - [x] Linux x86_32 `tools/jpackage` (pass cleanly)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8260592](https://bugs.openjdk.java.net/browse/JDK-8260592): jpackage tests fail when Desktop is not supported


### Reviewers
 * [Alexey Semenyuk](https://openjdk.java.net/census#asemenyuk) (@alexeysemenyukoracle - Author)


### Download
`$ git fetch https://git.openjdk.java.net/jdk16u pull/70/head:pull/70`
`$ git checkout pull/70`
