### PR TITLE
8241372: Several test failures due to javax.net.ssl.SSLException: Connection reset

### DIFF
--- a/test/jdk/javax/net/ssl/TLSCommon/TLSTest.java
+++ b/test/jdk/javax/net/ssl/TLSCommon/TLSTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,8 @@
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.security.KeyFactory;
 import java.security.KeyStore;
 import java.security.PrivateKey;
@@ -206,8 +208,11 @@ public class TLSTest {
                     keyType.getTrustedCert(), keyType.getEndCert(),
                     keyType.getPrivateKey(), keyType.getKeyType());
             SSLServerSocketFactory sslssf = ctx.getServerSocketFactory();
+            InetSocketAddress socketAddress =
+                    new InetSocketAddress(InetAddress.getLoopbackAddress(), port);
             SSLServerSocket sslServerSocket
-                    = (SSLServerSocket) sslssf.createServerSocket(port);
+                    = (SSLServerSocket) sslssf.createServerSocket();
+            sslServerSocket.bind(socketAddress);
             port = sslServerSocket.getLocalPort();
             System.out.println("Server listining on port: " + port);
             // specify the enabled server cipher suites

--- a/test/jdk/sun/security/ssl/CipherSuite/SupportedGroups.java
+++ b/test/jdk/sun/security/ssl/CipherSuite/SupportedGroups.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,6 +37,7 @@
   * @run main/othervm SupportedGroups ffdhe6144
   * @run main/othervm SupportedGroups ffdhe8192
  */
+import java.net.InetAddress;
 import java.util.Arrays;
 import javax.net.ssl.SSLSocket;
 import javax.net.ssl.SSLServerSocket;
@@ -50,6 +51,10 @@ public class SupportedGroups extends SSLSocketTemplate {
         {{"TLSv1.2"}, {"TLSv1.3", "TLSv1.2"}},
         {{"TLSv1.2"}, {"TLSv1.2"}}
     };
+
+    public SupportedGroups() {
+        this.serverAddress = InetAddress.getLoopbackAddress();
+    }
 
     // Servers are configured before clients, increment test case after.
     @Override

--- a/test/jdk/sun/security/ssl/SSLSocketImpl/ReverseNameLookup.java
+++ b/test/jdk/sun/security/ssl/SSLSocketImpl/ReverseNameLookup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,12 +24,15 @@
 /*
  * @test
  * @bug 4748292
+ * @library /test/lib
  * @summary Prevent/Disable reverse name lookups with JSSE SSL sockets
- * @run main/othervm ReverseNameLookup
+ * @run main/othervm ReverseNameLookup -Djava.net.preferIPv4Stack
  *
  *     SunJSSE does not support dynamic system properties, no way to re-use
  *     system properties in samevm/agentvm mode.
  */
+
+import jdk.test.lib.net.IPSupport;
 
 import java.io.*;
 import java.net.*;
@@ -86,8 +89,11 @@ public class ReverseNameLookup {
     void doServerSide() throws Exception {
         SSLServerSocketFactory sslssf =
             (SSLServerSocketFactory) SSLServerSocketFactory.getDefault();
+        InetSocketAddress socketAddress =
+                new InetSocketAddress(InetAddress.getLoopbackAddress(), serverPort);
         SSLServerSocket sslServerSocket =
-            (SSLServerSocket) sslssf.createServerSocket(serverPort);
+            (SSLServerSocket) sslssf.createServerSocket();
+        sslServerSocket.bind(socketAddress);
 
         serverPort = sslServerSocket.getLocalPort();
 
@@ -152,6 +158,7 @@ public class ReverseNameLookup {
     volatile Exception clientException = null;
 
     public static void main(String[] args) throws Exception {
+        IPSupport.throwSkippedExceptionIfNonOperational();
         String keyFilename =
             System.getProperty("test.src", "./") + "/" + pathToStores +
                 "/" + keyStoreFile;


### PR DESCRIPTION
This is a clean backport of:

8241372: Several test failures due to javax.net.ssl.SSLException: Connection reset

The patch applies clean. All tests have been run and verified to pass with the patch.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8241372](https://bugs.openjdk.java.net/browse/JDK-8241372): Several test failures due to javax.net.ssl.SSLException: Connection reset


### Download
`$ git fetch https://git.openjdk.java.net/jdk16u pull/71/head:pull/71`
`$ git checkout pull/71`
