### PR TITLE
8259679: GitHub actions should use MSVC 14.28

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -1022,7 +1022,7 @@ jobs:
         run: >
           Start-Process -FilePath 'C:\Program Files (x86)\Microsoft Visual Studio\Installer\vs_installer.exe' -Wait -NoNewWindow -ArgumentList
           'modify --installPath "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise" --quiet
-          --add Microsoft.VisualStudio.Component.VC.14.27.x86.x64'
+          --add Microsoft.VisualStudio.Component.VC.14.28.x86.x64'
 
       - name: Configure
         run: >
@@ -1033,7 +1033,7 @@ jobs:
           $env:GTEST = cygpath "$env:GITHUB_WORKSPACE/gtest" ;
           & bash configure
           --with-conf-name=windows-x64
-          --with-msvc-toolset-version=14.27
+          --with-msvc-toolset-version=14.28
           ${{ matrix.flags }}
           --with-version-opt="$env:GITHUB_ACTOR-$env:GITHUB_SHA"
           --with-version-build=0


### PR DESCRIPTION
Some GH action testing is failing in jdk16u now, for example: 
  https://github.com/shipilev/jdk16u/runs/2016544577?check_suite_focus=true

This should make GH actions more resilient.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8259679](https://bugs.openjdk.java.net/browse/JDK-8259679): GitHub actions should use MSVC 14.28


### Download
`$ git fetch https://git.openjdk.java.net/jdk16u pull/72/head:pull/72`
`$ git checkout pull/72`
