### PR TITLE
8257746: Regression introduced with JDK-8250984 - memory might be null in some machines

### DIFF
--- a/src/java.base/linux/classes/jdk/internal/platform/cgroupv1/CgroupV1Subsystem.java
+++ b/src/java.base/linux/classes/jdk/internal/platform/cgroupv1/CgroupV1Subsystem.java
@@ -444,14 +444,14 @@ public class CgroupV1Subsystem implements CgroupSubsystem, CgroupV1Metrics {
     }
 
     public long getMemoryAndSwapFailCount() {
-        if (!memory.isSwapEnabled()) {
+        if (memory != null && !memory.isSwapEnabled()) {
             return getMemoryFailCount();
         }
         return getLongValue(memory, "memory.memsw.failcnt");
     }
 
     public long getMemoryAndSwapLimit() {
-        if (!memory.isSwapEnabled()) {
+        if (memory != null && !memory.isSwapEnabled()) {
             return getMemoryLimit();
         }
         long retval = getLongValue(memory, "memory.memsw.limit_in_bytes");
@@ -469,14 +469,14 @@ public class CgroupV1Subsystem implements CgroupSubsystem, CgroupV1Metrics {
     }
 
     public long getMemoryAndSwapMaxUsage() {
-        if (!memory.isSwapEnabled()) {
+        if (memory != null && !memory.isSwapEnabled()) {
             return getMemoryMaxUsage();
         }
         return getLongValue(memory, "memory.memsw.max_usage_in_bytes");
     }
 
     public long getMemoryAndSwapUsage() {
-        if (!memory.isSwapEnabled()) {
+        if (memory != null && !memory.isSwapEnabled()) {
             return getMemoryUsage();
         }
         return getLongValue(memory, "memory.memsw.usage_in_bytes");


### PR DESCRIPTION
The patch for this fix applied cleanly.  The change was regression tested with tiers 1 and 2 on Linux, Mac OS, and Windows, and tiers 3-5 on Linux x64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8257746](https://bugs.openjdk.java.net/browse/JDK-8257746): Regression introduced with JDK-8250984 - memory might be null in some machines


### Download
`$ git fetch https://git.openjdk.java.net/jdk16u pull/73/head:pull/73`
`$ git checkout pull/73`
