### PR TITLE
8261397: Try Catch Method Failing to Work When Dividing An Integer By 0

### DIFF
--- a/src/hotspot/cpu/x86/vm_version_x86.hpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.hpp
@@ -1063,6 +1063,11 @@ public:
   static bool supports_clflushopt() { return ((_features & CPU_FLUSHOPT) != 0); }
   static bool supports_clwb() { return ((_features & CPU_CLWB) != 0); }
 
+#ifdef __APPLE__
+  // Is the CPU running emulated (for example macOS Rosetta running x86_64 code on M1 ARM (aarch64)
+  static bool is_cpu_emulated();
+#endif
+
   // support functions for virtualization detection
  private:
   static void check_virtualizations();

--- a/src/hotspot/os_cpu/bsd_x86/os_bsd_x86.cpp
+++ b/src/hotspot/os_cpu/bsd_x86/os_bsd_x86.cpp
@@ -472,7 +472,10 @@ bool PosixSignals::pd_hotspot_signal_handler(int sig, siginfo_t* info,
 
 #ifdef AMD64
       if (sig == SIGFPE  &&
-          (info->si_code == FPE_INTDIV || info->si_code == FPE_FLTDIV)) {
+          (info->si_code == FPE_INTDIV || info->si_code == FPE_FLTDIV
+           // Workaround for macOS ARM incorrectly reporting FPE_FLTINV for "div by 0"
+           // instead of the expected FPE_FLTDIV when running x86_64 binary under Rosetta emulation
+           MACOS_ONLY(|| (VM_Version::is_cpu_emulated() && info->si_code == FPE_FLTINV)))) {
         stub =
           SharedRuntime::
           continuation_for_implicit_exception(thread,

--- a/src/hotspot/os_cpu/bsd_x86/vm_version_bsd_x86.cpp
+++ b/src/hotspot/os_cpu/bsd_x86/vm_version_bsd_x86.cpp
@@ -25,3 +25,24 @@
 #include "precompiled.hpp"
 #include "runtime/os.hpp"
 #include "runtime/vm_version.hpp"
+
+#ifdef __APPLE__
+
+#include <sys/types.h>
+#include <sys/sysctl.h>
+
+bool VM_Version::is_cpu_emulated() {
+  int ret = 0;
+  size_t size = sizeof(ret);
+  // Is this process being ran in Rosetta (i.e. emulation) mode on macOS?
+  if (sysctlbyname("sysctl.proc_translated", &ret, &size, NULL, 0) == -1) {
+    // errno == ENOENT is a valid response, but anything else is a real error
+    if (errno != ENOENT) {
+      warning("unable to lookup sysctl.proc_translated");
+    }
+  }
+  return (ret==1);
+}
+
+#endif
+


### PR DESCRIPTION
The patch for the JDK-16u backport of the fix for JDK-8261397 applied cleanly.  It was regression tested on 16u with Mach5 tiers 1 and 2 on Linux, Mac OS, and Solaris, and Mach5 tiers 3-5 on Mac OS.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8261397](https://bugs.openjdk.java.net/browse/JDK-8261397): Try Catch Method Failing to Work When Dividing An Integer By 0


### Download
`$ git fetch https://git.openjdk.java.net/jdk16u pull/75/head:pull/75`
`$ git checkout pull/75`
