### PR TITLE
8261505: Test test/hotspot/jtreg/gc/parallel/TestDynShrinkHeap.java killed by Linux OOM Killer

### DIFF
--- a/test/hotspot/jtreg/gc/parallel/TestDynShrinkHeap.java
+++ b/test/hotspot/jtreg/gc/parallel/TestDynShrinkHeap.java
@@ -26,7 +26,7 @@ package gc.parallel;
 /**
  * @test TestDynShrinkHeap
  * @bug 8016479
- * @requires vm.gc.Parallel
+ * @requires vm.gc.Parallel & os.maxMemory > 1G
  * @summary Verify that the heap shrinks after full GC according to the current values of the Min/MaxHeapFreeRatio flags
  * @modules java.base/jdk.internal.misc
  * @modules jdk.management


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8261505](https://bugs.openjdk.java.net/browse/JDK-8261505): Test test/hotspot/jtreg/gc/parallel/TestDynShrinkHeap.java killed by Linux OOM Killer


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk16u pull/76/head:pull/76`
`$ git checkout pull/76`

To update a local copy of the PR:
`$ git checkout pull/76`
`$ git pull https://git.openjdk.java.net/jdk16u pull/76/head`
