### PR TITLE
8260401: StackOverflowError on open WindowsPreferences

### DIFF
--- a/src/java.prefs/windows/classes/java/util/prefs/WindowsPreferences.java
+++ b/src/java.prefs/windows/classes/java/util/prefs/WindowsPreferences.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -432,7 +432,7 @@ class WindowsPreferences extends AbstractPreferences {
         if (result[ERROR_CODE] != ERROR_SUCCESS) {
             logger().warning("Could not create windows registry node " +
                     byteArrayToString(windowsAbsolutePath()) +
-                    " at root 0x" + Long.toHexString(rootNativeHandle()) +
+                    " at root 0x" + Long.toHexString(parentNativeHandle) +
                     ". Windows RegCreateKeyEx(...) returned error code " +
                     result[ERROR_CODE] + ".");
             isBackingStoreAvailable = false;
@@ -458,7 +458,7 @@ class WindowsPreferences extends AbstractPreferences {
         if (result[ERROR_CODE] != ERROR_SUCCESS) {
             logger().warning("Could not open/create prefs root node " +
                     byteArrayToString(windowsAbsolutePath()) +
-                    " at root 0x" + Long.toHexString(rootNativeHandle()) +
+                    " at root 0x" + Long.toHexString(rootNativeHandle) +
                     ". Windows RegCreateKeyEx(...) returned error code " +
                     result[ERROR_CODE] + ".");
             isBackingStoreAvailable = false;


### PR DESCRIPTION
Hi, 

Please review this backport which prevents StackOverflowError occurring on Windows.

This occurs when users have incorrect registry access.

Regards,
Evan

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8260401](https://bugs.openjdk.java.net/browse/JDK-8260401): StackOverflowError on open WindowsPreferences


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk16u pull/78/head:pull/78` \
`$ git checkout pull/78`

Update a local copy of the PR: \
`$ git checkout pull/78` \
`$ git pull https://git.openjdk.java.net/jdk16u pull/78/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 78`

View PR using the GUI difftool: \
`$ git pr show -t 78`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk16u/pull/78.diff">https://git.openjdk.java.net/jdk16u/pull/78.diff</a>

</details>
