### PR TITLE
8262844: (fs) FileStore.supportsFileAttributeView might return false negative in case of ext3

### DIFF
--- a/src/java.base/linux/classes/sun/nio/fs/LinuxFileStore.java
+++ b/src/java.base/linux/classes/sun/nio/fs/LinuxFileStore.java
@@ -162,12 +162,6 @@ class LinuxFileStore
                 return false;
             }
 
-            // user_{no}xattr options not present but we special-case ext3 as
-            // we know that extended attributes are not enabled by default.
-            if (entry().fstype().equals("ext3")) {
-                return false;
-            }
-
             // user_xattr option not present but we special-case ext4 as we
             // know that extended attributes are enabled by default for
             // kernel version >= 2.6.39
@@ -184,7 +178,7 @@ class LinuxFileStore
                 return xattrEnabled;
             }
 
-            // not ext3/4 so probe mount point
+            // not ext4 so probe mount point
             if (!xattrChecked) {
                 UnixPath dir = new UnixPath(file().getFileSystem(), entry().dir());
                 xattrEnabled = isExtendedAttributesEnabled(dir);


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8262844](https://bugs.openjdk.java.net/browse/JDK-8262844): (fs) FileStore.supportsFileAttributeView might return false negative in case of ext3


### Download
`$ git fetch https://git.openjdk.java.net/jdk16u pull/80/head:pull/80`
`$ git checkout pull/80`
