### PR TITLE
8263030: Remove Shenandoah leftovers from ReferenceProcessor

### DIFF
--- a/src/hotspot/share/gc/shared/referenceProcessor.cpp
+++ b/src/hotspot/share/gc/shared/referenceProcessor.cpp
@@ -1164,8 +1164,7 @@ bool ReferenceProcessor::discover_reference(oop obj, ReferenceType rt) {
       // Check assumption that an object is not potentially
       // discovered twice except by concurrent collectors that potentially
       // trace the same Reference object twice.
-      assert(UseG1GC || UseShenandoahGC,
-             "Only possible with a concurrent marking collector");
+      assert(UseG1GC, "Only possible with a concurrent marking collector");
       return true;
     }
   }


### PR DESCRIPTION
Shenandoah is no longer using the shared ReferenceProcessor. We can remove remaining Shenandoah leftovers there.

Additional testing:
 - [x] Linux x86_64 fastdebug, `hotspot_gc_shenandoah`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8263030](https://bugs.openjdk.java.net/browse/JDK-8263030): Remove Shenandoah leftovers from ReferenceProcessor


### Download
`$ git fetch https://git.openjdk.java.net/jdk16u pull/81/head:pull/81`
`$ git checkout pull/81`
