### PR TITLE
8262446: DragAndDrop hangs on Windows

### DIFF
--- a/src/java.desktop/windows/native/libawt/windows/awt_DnDDT.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_DnDDT.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -141,6 +141,7 @@ static void ScaleDown(POINT &cp, HWND m_window) {
 
 HRESULT __stdcall AwtDropTarget::DragEnter(IDataObject __RPC_FAR *pDataObj, DWORD grfKeyState, POINTL pt, DWORD __RPC_FAR *pdwEffect) {
     TRY;
+    AwtToolkit::GetInstance().isInDoDragDropLoop = TRUE;
     if (NULL != m_pIDropTargetHelper) {
         m_pIDropTargetHelper->DragEnter(
             m_window,
@@ -160,6 +161,7 @@ HRESULT __stdcall AwtDropTarget::DragEnter(IDataObject __RPC_FAR *pDataObj, DWOR
         (IsLocalDnD()  && !IsLocalDataObject(pDataObj)))
     {
         *pdwEffect = retEffect;
+        AwtToolkit::GetInstance().isInDoDragDropLoop = FALSE;
         return ret;
     }
 
@@ -171,6 +173,7 @@ HRESULT __stdcall AwtDropTarget::DragEnter(IDataObject __RPC_FAR *pDataObj, DWOR
     }
 
     if (JNU_IsNull(env, m_dtcp) || !JNU_IsNull(env, safe_ExceptionOccurred(env))) {
+        AwtToolkit::GetInstance().isInDoDragDropLoop = FALSE;
         return ret;
     }
 
@@ -197,10 +200,12 @@ HRESULT __stdcall AwtDropTarget::DragEnter(IDataObject __RPC_FAR *pDataObj, DWOR
                 env->ExceptionDescribe();
                 env->ExceptionClear();
                 actions = java_awt_dnd_DnDConstants_ACTION_NONE;
+                AwtToolkit::GetInstance().isInDoDragDropLoop = FALSE;
             }
         } catch (std::bad_alloc&) {
             retEffect = ::convertActionsToDROPEFFECT(actions);
             *pdwEffect = retEffect;
+            AwtToolkit::GetInstance().isInDoDragDropLoop = FALSE;
             throw;
         }
 
@@ -416,6 +421,7 @@ void AwtDropTarget::DropDone(jboolean success, jint action) {
     m_dropSuccess = success;
     m_dropActions = action;
     AwtToolkit::GetInstance().QuitMessageLoop(AwtToolkit::EXIT_ENCLOSING_LOOP);
+    AwtToolkit::GetInstance().isInDoDragDropLoop = FALSE;
 }
 
 /**
@@ -1130,6 +1136,7 @@ void AwtDropTarget::UnloadCache() {
 
 void AwtDropTarget::DragCleanup(void) {
     UnloadCache();
+    AwtToolkit::GetInstance().isInDoDragDropLoop = FALSE;
 }
 
 BOOL AwtDropTarget::IsLocalDataObject(IDataObject __RPC_FAR *pDataObject) {


### PR DESCRIPTION
Clean back port of bf9b74d18767619f0765ed1435e35e28077a4220

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8262446](https://bugs.openjdk.java.net/browse/JDK-8262446): DragAndDrop hangs on Windows


### Download
`$ git fetch https://git.openjdk.java.net/jdk16u pull/82/head:pull/82`
`$ git checkout pull/82`
