### PR TITLE
8263136: C4530 was reported from VS 2019 at access bridge

### DIFF
--- a/src/jdk.accessibility/windows/native/common/AccessBridgeDebug.cpp
+++ b/src/jdk.accessibility/windows/native/common/AccessBridgeDebug.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,7 +32,6 @@
 #include <stdio.h>
 #include <windows.h>
 #include <cstdlib>
-#include <chrono>
 #include <cstring>
 
 #ifdef __cplusplus
@@ -72,11 +71,13 @@ void finalizeFileLogger() {
     }
 }
 
-auto getTimeStamp() -> long long {
-    using namespace std::chrono;
-    auto timeNow = duration_cast<milliseconds>(steady_clock::now().time_since_epoch());
-
-    return timeNow.count();
+unsigned long long getTimeStamp() {
+    FILETIME ft;
+    ULARGE_INTEGER uli;
+    GetSystemTimeAsFileTime(&ft);
+    uli.LowPart = ft.dwLowDateTime;
+    uli.HighPart = ft.dwHighDateTime;
+    return (uli.QuadPart / 10000ULL) - 11644473600000ULL; // Rebase Epoch from 1601 to 1970
 }
 
 /**


### PR DESCRIPTION
Seeing the similar failure in JDK 16u GHA testing. Backport this one should help.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8263136](https://bugs.openjdk.java.net/browse/JDK-8263136): C4530 was reported from VS 2019 at access bridge


### Download
`$ git fetch https://git.openjdk.java.net/jdk16u pull/84/head:pull/84`
`$ git checkout pull/84`
