### PR TITLE
8263557: Possible NULL dereference in Arena::destruct_contents()

### DIFF
--- a/src/hotspot/share/memory/arena.cpp
+++ b/src/hotspot/share/memory/arena.cpp
@@ -316,7 +316,9 @@ void Arena::destruct_contents() {
   // reset size before chop to avoid a rare racing condition
   // that can have total arena memory exceed total chunk memory
   set_size_in_bytes(0);
-  _first->chop();
+  if (_first != NULL) {
+    _first->chop();
+  }
   reset();
 }
 


### PR DESCRIPTION
The patch for this JDK-16u backport of JDK-8263557 applied cleanly.  The fix was regression tested by running Mach5 tiers 1 and 2 on Linux, Windows, and Mac OS.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8263557](https://bugs.openjdk.java.net/browse/JDK-8263557): Possible NULL dereference in Arena::destruct_contents()


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk16u pull/88/head:pull/88`
`$ git checkout pull/88`

To update a local copy of the PR:
`$ git checkout pull/88`
`$ git pull https://git.openjdk.java.net/jdk16u pull/88/head`
