### PR TITLE
8263430: Uninitialized Method* variables after JDK-8233913

### DIFF
--- a/src/hotspot/share/interpreter/linkResolver.cpp
+++ b/src/hotspot/share/interpreter/linkResolver.cpp
@@ -1149,7 +1149,7 @@ Method* LinkResolver::linktime_resolve_special_method(const LinkInfo& link_info,
   // and the selected method is recalculated relative to the direct superclass
   // superinterface.method, which explicitly does not check shadowing
   Klass* resolved_klass = link_info.resolved_klass();
-  Method* resolved_method;
+  Method* resolved_method = NULL;
 
   if (!resolved_klass->is_interface()) {
     resolved_method = resolve_method(link_info, Bytecodes::_invokespecial, CHECK_NULL);

--- a/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
+++ b/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
@@ -370,7 +370,7 @@ C2V_VMENTRY_NULL(jobject, asResolvedJavaMethod, (JNIEnv* env, jobject, jobject e
 }
 
 C2V_VMENTRY_NULL(jobject, getResolvedJavaMethod, (JNIEnv* env, jobject, jobject base, jlong offset))
-  Method* method;
+  Method* method = NULL;
   JVMCIObject base_object = JVMCIENV->wrap(base);
   if (base_object.is_null()) {
     method = *((Method**)(offset));

--- a/src/hotspot/share/jvmci/jvmciJavaClasses.cpp
+++ b/src/hotspot/share/jvmci/jvmciJavaClasses.cpp
@@ -90,7 +90,7 @@ void HotSpotJVMCI::compute_offset(int &dest_offset, Klass* klass, const char* na
 
 #ifndef PRODUCT
 static void check_resolve_method(const char* call_type, Klass* resolved_klass, Symbol* method_name, Symbol* method_signature, TRAPS) {
-  Method* method;
+  Method* method = NULL;
   LinkInfo link_info(resolved_klass, method_name, method_signature, NULL, LinkInfo::AccessCheck::skip, LinkInfo::LoaderConstraintCheck::skip);
   if (strcmp(call_type, "call_static") == 0) {
     method = LinkResolver::resolve_static_call_or_null(link_info);


### PR DESCRIPTION
The patch for this JDK-16u backport applied cleanly.  It was tested with Mach5 tiers 1 and 2 on Linux, Mac OS, and Windows.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8263430](https://bugs.openjdk.java.net/browse/JDK-8263430): Uninitialized Method* variables after JDK-8233913


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk16u pull/89/head:pull/89`
`$ git checkout pull/89`

To update a local copy of the PR:
`$ git checkout pull/89`
`$ git pull https://git.openjdk.java.net/jdk16u pull/89/head`
