### PR TITLE
8263968: CDS: java/lang/ModuleLayer.EMPTY_LAYER should be singleton

### DIFF
--- a/src/hotspot/share/memory/heapShared.cpp
+++ b/src/hotspot/share/memory/heapShared.cpp
@@ -92,6 +92,7 @@ static ArchivableStaticFieldInfo closed_archive_subgraph_entry_fields[] = {
 static ArchivableStaticFieldInfo open_archive_subgraph_entry_fields[] = {
   {"jdk/internal/module/ArchivedModuleGraph",     "archivedModuleGraph"},
   {"java/util/ImmutableCollections",              "archivedObjects"},
+  {"java/lang/ModuleLayer",                       "EMPTY_LAYER"},
   {"java/lang/module/Configuration",              "EMPTY_CONFIGURATION"},
   {"jdk/internal/math/FDBigInteger",              "archivedCaches"},
 };

--- a/src/java.base/share/classes/java/lang/ModuleLayer.java
+++ b/src/java.base/share/classes/java/lang/ModuleLayer.java
@@ -48,6 +48,8 @@ import jdk.internal.loader.ClassLoaderValue;
 import jdk.internal.loader.Loader;
 import jdk.internal.loader.LoaderPool;
 import jdk.internal.module.ServicesCatalog;
+import jdk.internal.misc.CDS;
+import jdk.internal.vm.annotation.Stable;
 import sun.security.util.SecurityConstants;
 
 
@@ -147,9 +149,15 @@ import sun.security.util.SecurityConstants;
 
 public final class ModuleLayer {
 
-    // the empty layer
-    private static final ModuleLayer EMPTY_LAYER
-        = new ModuleLayer(Configuration.empty(), List.of(), null);
+    // the empty layer (may be initialized from the CDS archive)
+    private static @Stable ModuleLayer EMPTY_LAYER;
+    static {
+        CDS.initializeFromArchive(ModuleLayer.class);
+        if (EMPTY_LAYER == null) {
+            // create a new empty layer if there is no archived version.
+            EMPTY_LAYER = new ModuleLayer(Configuration.empty(), List.of(), null);
+        }
+    }
 
     // the configuration from which this layer was created
     private final Configuration cf;

--- a/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/CheckArchivedModuleApp.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/CheckArchivedModuleApp.java
@@ -61,6 +61,7 @@ public class CheckArchivedModuleApp {
         checkModuleDescriptors(expectArchivedDescriptors);
         checkConfiguration(expectArchivedConfiguration);
         checkEmptyConfiguration(expectArchivedConfiguration);
+        checkEmptyLayer();
     }
 
     private static void checkModuleDescriptors(boolean expectArchivedDescriptors) {
@@ -137,6 +138,15 @@ public class CheckArchivedModuleApp {
                 throw new RuntimeException(
                     "FAILED. Boot layer configuration is archived.");
             }
+        }
+    }
+
+    private static void checkEmptyLayer() {
+        // ModuleLayer.EMPTY_FIELD returned by empty() method is singleton.
+        // Check that with CDS there is still a single instance of EMPTY_LAYER
+        // and boot() layer parent is THE empty layer.
+        if (ModuleLayer.empty() != ModuleLayer.boot().parents().get(0)) {
+            throw new RuntimeException("FAILED. Empty module layer is not singleton");
         }
     }
 }


### PR DESCRIPTION
This is the jdk16u backport of the fix for JDK-8263968. The original patch applies cleanly without modification. Tested with JCK and jtreg.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8263968](https://bugs.openjdk.java.net/browse/JDK-8263968): CDS: java/lang/ModuleLayer.EMPTY_LAYER should be singleton


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk16u pull/90/head:pull/90`
`$ git checkout pull/90`

To update a local copy of the PR:
`$ git checkout pull/90`
`$ git pull https://git.openjdk.java.net/jdk16u pull/90/head`
