### PR TITLE
8259662: Don't wrap SocketExceptions into SSLExceptions in SSLSocketImpl

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/SSLSocketImpl.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLSocketImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -74,6 +74,16 @@ import jdk.internal.access.SharedSecrets;
  */
 public final class SSLSocketImpl
         extends BaseSSLSocketImpl implements SSLTransport {
+
+    /**
+     * ERROR HANDLING GUIDELINES
+     * (which exceptions to throw and catch and which not to throw and catch)
+     *
+     * - if there is an IOException (SocketException) when accessing the
+     *   underlying Socket, pass it through
+     *
+     * - do not throw IOExceptions, throw SSLExceptions (or a subclass)
+     */
 
     final SSLContextImpl            sslContext;
     final TransportContext          conContext;
@@ -447,6 +457,8 @@ public final class SSLSocketImpl
                     throw conContext.fatal(Alert.HANDSHAKE_FAILURE,
                             "Couldn't kickstart handshaking", iioe);
                 }
+            } catch (SocketException se) {
+                handleException(se);
             } catch (IOException ioe) {
                 throw conContext.fatal(Alert.HANDSHAKE_FAILURE,
                     "Couldn't kickstart handshaking", ioe);
@@ -1406,11 +1418,9 @@ public final class SSLSocketImpl
                         conContext.isNegotiated) {
                     return 0;
                 }
-            } catch (SSLException ssle) {
-                throw ssle;
-            } catch (InterruptedIOException iioe) {
-                // don't change exception in case of timeouts or interrupts
-                throw iioe;
+            } catch (SSLException | InterruptedIOException | SocketException se) {
+                // don't change exception in case of timeouts or interrupts or SocketException
+                throw se;
             } catch (IOException ioe) {
                 throw new SSLException("readHandshakeRecord", ioe);
             }
@@ -1471,11 +1481,9 @@ public final class SSLSocketImpl
                         buffer.position() > 0) {
                     return buffer;
                 }
-            } catch (SSLException ssle) {
-                throw ssle;
-            } catch (InterruptedIOException iioe) {
-                // don't change exception in case of timeouts or interrupts
-                throw iioe;
+            } catch (SSLException | InterruptedIOException | SocketException se) {
+                // don't change exception in case of timeouts or interrupts or SocketException.
+                throw se;
             } catch (IOException ioe) {
                 if (!(ioe instanceof SSLException)) {
                     throw new SSLException("readApplicationRecord", ioe);
@@ -1685,6 +1693,16 @@ public final class SSLSocketImpl
                 // RuntimeException
                 alert = Alert.INTERNAL_ERROR;
             }
+        }
+
+        if (cause instanceof SocketException) {
+            try {
+                conContext.fatal(alert, cause);
+            } catch (Exception e) {
+                // Just delivering the fatal alert, re-throw the socket exception instead.
+            }
+
+            throw (SocketException)cause;
         }
 
         throw conContext.fatal(alert, cause);

--- a/src/java.base/share/classes/sun/security/ssl/SSLTransport.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLTransport.java
@@ -28,6 +28,7 @@ package sun.security.ssl;
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.InterruptedIOException;
+import java.net.SocketException;
 import java.nio.ByteBuffer;
 import javax.crypto.AEADBadTagException;
 import javax.crypto.BadPaddingException;
@@ -137,9 +138,9 @@ interface SSLTransport {
         } catch (EOFException eofe) {
             // rethrow EOFException, the call will handle it if neede.
             throw eofe;
-        } catch (InterruptedIOException iioe) {
-            // don't close the Socket in case of timeouts or interrupts.
-            throw iioe;
+        } catch (InterruptedIOException | SocketException se) {
+            // don't close the Socket in case of timeouts or interrupts or SocketException.
+            throw se;
         } catch (IOException ioe) {
             throw context.fatal(Alert.UNEXPECTED_MESSAGE, ioe);
         }

--- a/src/java.base/share/classes/sun/security/ssl/SSLTransport.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLTransport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/net/httpclient/InvalidSSLContextTest.java
+++ b/test/jdk/java/net/httpclient/InvalidSSLContextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,6 +37,7 @@ import java.net.InetSocketAddress;
 import java.net.URI;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.net.SocketException;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLHandshakeException;
@@ -173,8 +174,8 @@ public class InvalidSSLContextTest {
                         s.startHandshake();
                         s.close();
                         Assert.fail("SERVER: UNEXPECTED ");
-                    } catch (SSLException he) {
-                        System.out.println("SERVER: caught expected " + he);
+                    } catch (SSLException | SocketException se) {
+                        System.out.println("SERVER: caught expected " + se);
                     } catch (IOException e) {
                         System.out.println("SERVER: caught: " + e);
                         if (!sslServerSocket.isClosed()) {

--- a/test/jdk/javax/net/ssl/SSLSession/TestEnabledProtocols.java
+++ b/test/jdk/javax/net/ssl/SSLSession/TestEnabledProtocols.java
@@ -89,10 +89,10 @@ public class TestEnabledProtocols extends SSLSocketTemplate {
             se.printStackTrace(System.out);
         } catch (InterruptedIOException ioe) {
             // must have been interrupted, no harm
-        } catch (SSLException ssle) {
+        } catch (SSLException | SocketException se) {
             // The client side may have closed the socket.
             System.out.println("Server SSLException:");
-            ssle.printStackTrace(System.out);
+            se.printStackTrace(System.out);
         } catch (Exception e) {
             System.out.println("Server exception:");
             e.printStackTrace(System.out);

--- a/test/jdk/sun/security/ssl/SSLContextImpl/TrustTrustedCert.java
+++ b/test/jdk/sun/security/ssl/SSLContextImpl/TrustTrustedCert.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -131,9 +131,9 @@ public class TrustTrustedCert extends SSLSocketTemplate {
             sslIS.read();
             sslOS.write('A');
             sslOS.flush();
-        } catch (SSLException ssle) {
+        } catch (SSLException | SocketException se) {
             if (!expectFail) {
-                throw ssle;
+                throw se;
             }   // Otherwise, ignore.
         }
     }

--- a/test/jdk/sun/security/ssl/SSLSocketImpl/SSLSocketShouldThrowSocketException.java
+++ b/test/jdk/sun/security/ssl/SSLSocketImpl/SSLSocketShouldThrowSocketException.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2021, Amazon and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8214339 8259662
+ * @summary When a SocketException is thrown by the underlying layer, It
+ *      should be thrown as is and not be transformed to an SSLException.
+ * @library /javax/net/ssl/templates
+ * @run main/othervm SSLSocketShouldThrowSocketException
+ */
+
+import java.io.*;
+import java.net.*;
+import java.util.*;
+import java.security.*;
+import javax.net.ssl.*;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+public class SSLSocketShouldThrowSocketException extends SSLSocketTemplate {
+
+    boolean handshake;
+
+    private final CountDownLatch clientTerminatedCondition = new CountDownLatch(1);
+
+    SSLSocketShouldThrowSocketException(boolean handshake) {
+        this.handshake = handshake;
+    }
+
+    @Override
+    protected boolean isCustomizedClientConnection() {
+        return true;
+    }
+
+    @Override
+    protected void runServerApplication(SSLSocket socket) throws Exception {
+        clientTerminatedCondition.await(30L, TimeUnit.SECONDS);
+    }
+
+    @Override
+    protected void runClientApplication(int serverPort) throws Exception {
+        Socket baseSocket = new Socket("localhost", serverPort);
+
+        SSLSocketFactory sslsf =
+                (SSLSocketFactory) SSLSocketFactory.getDefault();
+        SSLSocket sslSocket = (SSLSocket)
+                sslsf.createSocket(baseSocket, "localhost", serverPort, false);
+
+        if (this.handshake) {
+            testHandshakeClose(baseSocket, sslSocket);
+        } else {
+            testDataClose(baseSocket, sslSocket);
+        }
+
+        clientTerminatedCondition.countDown();
+
+    }
+
+    private void testHandshakeClose(Socket baseSocket, SSLSocket sslSocket) throws Exception {
+        Thread aborter = new Thread() {
+            @Override
+            public void run() {
+
+                try {
+                    Thread.sleep(10);
+                    System.err.println("Closing the client socket : " + System.nanoTime());
+                    baseSocket.close();
+                } catch (Exception ieo) {
+                    ieo.printStackTrace();
+                }
+            }
+        };
+
+        aborter.start();
+
+        try {
+            // handshaking
+            System.err.println("Client starting handshake: " + System.nanoTime());
+            sslSocket.startHandshake();
+            throw new Exception("Start handshake did not throw an exception");
+        } catch (SocketException se) {
+            System.err.println("Caught Expected SocketException");
+        }
+
+        aborter.join();
+    }
+
+    private void testDataClose(Socket baseSocket, SSLSocket sslSocket) throws Exception{
+
+        CountDownLatch handshakeCondition = new CountDownLatch(1);
+
+        Thread aborter = new Thread() {
+            @Override
+            public void run() {
+
+                try {
+                    handshakeCondition.await(10L, TimeUnit.SECONDS);
+                    System.err.println("Closing the client socket : " + System.nanoTime());
+                    baseSocket.close();
+                } catch (Exception ieo) {
+                    ieo.printStackTrace();
+                }
+            }
+        };
+
+        aborter.start();
+
+        try {
+            // handshaking
+            System.err.println("Client starting handshake: " + System.nanoTime());
+            sslSocket.startHandshake();
+            handshakeCondition.countDown();
+            System.err.println("Reading data from server");
+            BufferedReader is = new BufferedReader(
+                    new InputStreamReader(sslSocket.getInputStream()));
+            String data = is.readLine();
+            throw new Exception("Start handshake did not throw an exception");
+        } catch (SocketException se) {
+            System.err.println("Caught Expected SocketException");
+        }
+
+        aborter.join();
+    }
+
+    public static void main(String[] args) throws Exception {
+        // SocketException should be throws during a handshake phase.
+        (new SSLSocketShouldThrowSocketException(true)).run();
+        // SocketException should be throw during the application data phase.
+        (new SSLSocketShouldThrowSocketException(false)).run();
+    }
+}

--- a/test/jdk/sun/security/ssl/SSLSocketImpl/SocketExceptionForSocketIssues.java
+++ b/test/jdk/sun/security/ssl/SSLSocketImpl/SocketExceptionForSocketIssues.java
@@ -31,18 +31,18 @@
  * @bug 8214339
  * @summary SSLSocketImpl erroneously wraps SocketException
  * @library /javax/net/ssl/templates
- * @run main/othervm SSLExceptionForIOIssue
+ * @run main/othervm SocketExceptionForSocketIssues
  */
 
 import javax.net.ssl.*;
 import java.io.*;
 import java.net.*;
 
-public class SSLExceptionForIOIssue implements SSLContextTemplate {
+public class SocketExceptionForSocketIssues implements SSLContextTemplate {
 
     public static void main(String[] args) throws Exception {
         System.err.println("===================================");
-        new SSLExceptionForIOIssue().test();
+        new SocketExceptionForSocketIssues().test();
     }
 
     private void test() throws Exception {
@@ -79,9 +79,9 @@ public class SSLExceptionForIOIssue implements SSLContextTemplate {
             os.flush();
         } catch (SSLProtocolException | SSLHandshakeException sslhe) {
             throw sslhe;
-        } catch (SSLException ssle) {
+        } catch (SocketException se) {
             // the expected exception, ignore it
-            System.err.println("server exception: " + ssle);
+            System.err.println("server exception: " + se);
         } finally {
             if (listenSocket != null) {
                 listenSocket.close();


### PR DESCRIPTION
Please review this backport to 16u. The backport is clean, except for syntax-only
changes to catch expressions, and one context change in SSLSocketImpl.java.

Original JBS: https://bugs.openjdk.java.net/browse/JDK-8259662
Original commit: https://github.com/openjdk/jdk/commit/63f8fc87

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8259662](https://bugs.openjdk.java.net/browse/JDK-8259662): Don't wrap SocketExceptions into SSLExceptions in SSLSocketImpl ⚠️ Issue is not open.


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk16u pull/93/head:pull/93`
`$ git checkout pull/93`

To update a local copy of the PR:
`$ git checkout pull/93`
`$ git pull https://git.openjdk.java.net/jdk16u pull/93/head`
