### PR TITLE
8261262: Kitchensink24HStress.java crashed with EXCEPTION_ACCESS_VIOLATION

### DIFF
--- a/src/hotspot/share/prims/jvmtiEnvThreadState.cpp
+++ b/src/hotspot/share/prims/jvmtiEnvThreadState.cpp
@@ -259,19 +259,16 @@ class GetCurrentLocationClosure : public HandshakeClosure {
     JavaThread *jt = target->as_Java_thread();
     ResourceMark rmark; // jt != Thread::current()
     RegisterMap rm(jt, false);
-    // There can be a race condition between a VM_Operation reaching a safepoint
+    // There can be a race condition between a handshake
     // and the target thread exiting from Java execution.
-    // We must recheck the last Java frame still exists.
+    // We must recheck that the last Java frame still exists.
     if (!jt->is_exiting() && jt->has_last_Java_frame()) {
       javaVFrame* vf = jt->last_java_vframe(&rm);
-      assert(vf != NULL, "must have last java frame");
-      Method* method = vf->method();
-      _method_id = method->jmethod_id();
-      _bci = vf->bci();
-    } else {
-      // Clear current location as the target thread has no Java frames anymore.
-      _method_id = (jmethodID)NULL;
-      _bci = 0;
+      if (vf != NULL) {
+        Method* method = vf->method();
+        _method_id = method->jmethod_id();
+        _bci = vf->bci();
+      }
     }
     _completed = true;
   }


### PR DESCRIPTION
Backport of JDK-8261262 to JDK-16u.  The patch applied cleanly and was tested with Mach5 tiers 1-2 on Linux, Mac OS, and Windows and tiers 3-5 on Linux x64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8261262](https://bugs.openjdk.java.net/browse/JDK-8261262): Kitchensink24HStress.java crashed with EXCEPTION_ACCESS_VIOLATION


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk16u pull/96/head:pull/96` \
`$ git checkout pull/96`

Update a local copy of the PR: \
`$ git checkout pull/96` \
`$ git pull https://git.openjdk.java.net/jdk16u pull/96/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 96`

View PR using the GUI difftool: \
`$ git pr show -t 96`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk16u/pull/96.diff">https://git.openjdk.java.net/jdk16u/pull/96.diff</a>

</details>
