### PR TITLE
8262110: DST starts from incorrect time in 2038

### DIFF
--- a/src/java.base/share/classes/sun/util/calendar/ZoneInfo.java
+++ b/src/java.base/share/classes/sun/util/calendar/ZoneInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -285,7 +285,7 @@ public class ZoneInfo extends TimeZone {
             int dstoffset = tz.getOffset(msec) - rawOffset;
 
             // Check if it's in a standard-to-daylight transition.
-            if (dstoffset > 0 && tz.getOffset(msec - dstoffset) == rawoffset) {
+            if (dstoffset > 0 && tz.getOffset(msec - dstoffset) == rawoffset && type == WALL_TIME) {
                 dstoffset = 0;
             }
 

--- a/test/jdk/sun/util/calendar/zi/Beyond2037.java
+++ b/test/jdk/sun/util/calendar/zi/Beyond2037.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8073446 8262110
+ * @summary Tests DST related beyond the year 2037
+ * @run testng Beyond2037
+ */
+
+import java.text.SimpleDateFormat;
+import java.util.TimeZone;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import static org.testng.Assert.assertEquals;
+
+@Test
+public class Beyond2037 {
+
+    @DataProvider
+    Object[][] dstTransition() {
+        return new Object[][] {
+            {"2037/03/08 01:59:59:999", "2037/03/08 01:59:59:999"},
+            {"2037/03/08 02:00:00:000", "2037/03/08 03:00:00:000"},
+            {"2038/03/14 01:59:59:999", "2038/03/14 01:59:59:999"},
+            {"2038/03/14 02:00:00:000", "2038/03/14 03:00:00:000"},
+            {"2099/03/08 01:59:59:999", "2099/03/08 01:59:59:999"},
+            {"2099/03/08 02:00:00:000", "2099/03/08 03:00:00:000"},
+            {"2100/03/14 01:59:59:999", "2100/03/14 01:59:59:999"},
+            {"2100/03/14 02:00:00:000", "2100/03/14 03:00:00:000"},
+            {"8000/03/12 01:59:59:999", "8000/03/12 01:59:59:999"},
+            {"8000/03/12 02:00:00:000", "8000/03/12 03:00:00:000"},
+        };
+    }
+
+    @Test(dataProvider="dstTransition")
+    public void testDstTransition(String source, String expected) throws Exception {
+        var timeZone = TimeZone.getTimeZone("America/New_York");
+        var sdf = new SimpleDateFormat("yyyy/MM/dd HH:mm:ss:SSS" );
+        sdf.setTimeZone(timeZone);
+        assertEquals(sdf.format(sdf.parse(source)), expected);
+    }
+
+    @Test
+    public void testGetOffset() throws Exception {
+        var timeZone = TimeZone.getTimeZone("PST8PDT");
+        var df = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        df.setTimeZone(timeZone);
+        var tMilli = df.parse("7681-03-09 03:20:49").getTime();
+        assertEquals(timeZone.getOffset(tMilli), -25200000);
+    }
+}


### PR DESCRIPTION
Backport to 16u as it is a long-standing bug in Calendar API. Passed regression

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issues
 * [JDK-8262110](https://bugs.openjdk.java.net/browse/JDK-8262110): DST starts from incorrect time in 2038
 * [JDK-8073446](https://bugs.openjdk.java.net/browse/JDK-8073446): TimeZone getOffset API does not  return a dst offset between years 2038-2137


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk16u pull/104/head:pull/104` \
`$ git checkout pull/104`

Update a local copy of the PR: \
`$ git checkout pull/104` \
`$ git pull https://git.openjdk.java.net/jdk16u pull/104/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 104`

View PR using the GUI difftool: \
`$ git pr show -t 104`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk16u/pull/104.diff">https://git.openjdk.java.net/jdk16u/pull/104.diff</a>

</details>
