### PR TITLE
8258414: OldObjectSample events too expensive

### DIFF
--- a/src/hotspot/share/jfr/leakprofiler/checkpoint/objectSampleCheckpoint.hpp
+++ b/src/hotspot/share/jfr/leakprofiler/checkpoint/objectSampleCheckpoint.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,7 +33,6 @@ class InstanceKlass;
 class JavaThread;
 class JfrCheckpointWriter;
 class JfrStackTrace;
-class JfrStackTraceRepository;
 class Klass;
 class ObjectSample;
 class ObjectSampleMarker;
@@ -53,7 +52,7 @@ class ObjectSampleCheckpoint : AllStatic {
   static void on_type_set(JfrCheckpointWriter& writer);
   static void on_type_set_unload(JfrCheckpointWriter& writer);
   static void on_thread_exit(JavaThread* jt);
-  static void on_rotation(const ObjectSampler* sampler, JfrStackTraceRepository& repo);
+  static void on_rotation(const ObjectSampler* sampler);
 };
 
 #endif // SHARE_JFR_LEAKPROFILER_CHECKPOINT_OBJECTSAMPLECHECKPOINT_HPP

--- a/src/hotspot/share/jfr/leakprofiler/sampling/objectSampler.cpp
+++ b/src/hotspot/share/jfr/leakprofiler/sampling/objectSampler.cpp
@@ -158,12 +158,23 @@ static traceid get_thread_id(JavaThread* thread) {
   return tl->thread_id();
 }
 
-static void record_stacktrace(JavaThread* thread) {
-  assert(thread != NULL, "invariant");
-  if (JfrEventSetting::has_stacktrace(EventOldObjectSample::eventId)) {
-    JfrStackTraceRepository::record_and_cache(thread);
+class RecordStackTrace {
+ private:
+  JavaThread* _jt;
+  bool _enabled;
+ public:
+  RecordStackTrace(JavaThread* jt) : _jt(jt),
+    _enabled(JfrEventSetting::has_stacktrace(EventOldObjectSample::eventId)) {
+    if (_enabled) {
+      JfrStackTraceRepository::record_for_leak_profiler(jt);
+    }
   }
-}
+  ~RecordStackTrace() {
+    if (_enabled) {
+      _jt->jfr_thread_local()->clear_cached_stack_trace();
+    }
+  }
+};
 
 void ObjectSampler::sample(HeapWord* obj, size_t allocated, JavaThread* thread) {
   assert(thread != NULL, "invariant");
@@ -172,7 +183,7 @@ void ObjectSampler::sample(HeapWord* obj, size_t allocated, JavaThread* thread) 
   if (thread_id == 0) {
     return;
   }
-  record_stacktrace(thread);
+  RecordStackTrace rst(thread);
   // try enter critical section
   JfrTryLock tryLock(&_lock);
   if (!tryLock.acquired()) {

--- a/src/hotspot/share/jfr/recorder/checkpoint/types/traceid/jfrTraceId.hpp
+++ b/src/hotspot/share/jfr/recorder/checkpoint/types/traceid/jfrTraceId.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -100,7 +100,6 @@ class JfrTraceId : public AllStatic {
   static traceid load_raw(jclass jc);
   static traceid load_raw(const Thread* thread);
   static traceid load_raw(const Method* method);
-  static traceid load_raw(const Klass* klass, const Method* method);
   static traceid load_raw(const ModuleEntry* module);
   static traceid load_raw(const PackageEntry* package);
   static traceid load_raw(const ClassLoaderData* cld);

--- a/src/hotspot/share/jfr/recorder/service/jfrRecorderService.cpp
+++ b/src/hotspot/share/jfr/recorder/service/jfrRecorderService.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -437,7 +437,7 @@ void JfrRecorderService::clear() {
 void JfrRecorderService::pre_safepoint_clear() {
   _string_pool.clear();
   _storage.clear();
-  _stack_trace_repository.clear();
+  JfrStackTraceRepository::clear();
 }
 
 void JfrRecorderService::invoke_safepoint_clear() {
@@ -452,7 +452,7 @@ void JfrRecorderService::safepoint_clear() {
   _string_pool.clear();
   _storage.clear();
   _chunkwriter.set_time_stamp();
-  _stack_trace_repository.clear();
+  JfrStackTraceRepository::clear();
   _checkpoint_manager.end_epoch_shift();
 }
 
@@ -539,7 +539,7 @@ void JfrRecorderService::pre_safepoint_write() {
   if (LeakProfiler::is_running()) {
     // Exclusive access to the object sampler instance.
     // The sampler is released (unlocked) later in post_safepoint_write.
-    ObjectSampleCheckpoint::on_rotation(ObjectSampler::acquire(), _stack_trace_repository);
+    ObjectSampleCheckpoint::on_rotation(ObjectSampler::acquire());
   }
   if (_string_pool.is_modified()) {
     write_stringpool(_string_pool, _chunkwriter);
@@ -560,6 +560,7 @@ void JfrRecorderService::invoke_safepoint_write() {
 void JfrRecorderService::safepoint_write() {
   assert(SafepointSynchronize::is_at_safepoint(), "invariant");
   _checkpoint_manager.begin_epoch_shift();
+  JfrStackTraceRepository::clear_leak_profiler();
   if (_string_pool.is_modified()) {
     write_stringpool(_string_pool, _chunkwriter);
   }

--- a/src/hotspot/share/jfr/recorder/stacktrace/jfrStackTraceRepository.cpp
+++ b/src/hotspot/share/jfr/recorder/stacktrace/jfrStackTraceRepository.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,18 +30,38 @@
 #include "jfr/support/jfrThreadLocal.hpp"
 #include "runtime/mutexLocker.hpp"
 
-static JfrStackTraceRepository* _instance = NULL;
+/*
+ * There are two separate repository instances.
+ * One instance is dedicated to stacktraces taken as part of the leak profiler subsystem.
+ * It is kept separate because at the point of insertion, it is unclear if a trace will be serialized,
+ * which is a decision postponed and taken during rotation.
+ */
 
-JfrStackTraceRepository::JfrStackTraceRepository() : _next_id(0), _entries(0) {
-  memset(_table, 0, sizeof(_table));
-}
+static JfrStackTraceRepository* _instance = NULL;
+static JfrStackTraceRepository* _leak_profiler_instance = NULL;
+static traceid _next_id = 0;
 
 JfrStackTraceRepository& JfrStackTraceRepository::instance() {
+  assert(_instance != NULL, "invariant");
   return *_instance;
+}
+
+static JfrStackTraceRepository& leak_profiler_instance() {
+  assert(_leak_profiler_instance != NULL, "invariant");
+  return *_leak_profiler_instance;
+}
+
+JfrStackTraceRepository::JfrStackTraceRepository() : _last_entries(0), _entries(0) {
+  memset(_table, 0, sizeof(_table));
 }
 
 JfrStackTraceRepository* JfrStackTraceRepository::create() {
   assert(_instance == NULL, "invariant");
+  assert(_leak_profiler_instance == NULL, "invariant");
+  _leak_profiler_instance = new JfrStackTraceRepository();
+  if (_leak_profiler_instance == NULL) {
+    return NULL;
+  }
   _instance = new JfrStackTraceRepository();
   return _instance;
 }
@@ -69,12 +89,12 @@ void JfrStackTraceRepository::destroy() {
   assert(_instance != NULL, "invarinat");
   delete _instance;
   _instance = NULL;
+  delete _leak_profiler_instance;
+  _leak_profiler_instance = NULL;
 }
 
-static traceid last_id = 0;
-
 bool JfrStackTraceRepository::is_modified() const {
-  return last_id != _next_id;
+  return _last_entries != _entries;
 }
 
 size_t JfrStackTraceRepository::write(JfrChunkWriter& sw, bool clear) {
@@ -102,26 +122,27 @@ size_t JfrStackTraceRepository::write(JfrChunkWriter& sw, bool clear) {
     memset(_table, 0, sizeof(_table));
     _entries = 0;
   }
-  last_id = _next_id;
+  _last_entries = _entries;
   return count;
 }
 
-size_t JfrStackTraceRepository::clear() {
+size_t JfrStackTraceRepository::clear(JfrStackTraceRepository& repo) {
   MutexLocker lock(JfrStacktrace_lock, Mutex::_no_safepoint_check_flag);
-  if (_entries == 0) {
+  if (repo._entries == 0) {
     return 0;
   }
   for (u4 i = 0; i < TABLE_SIZE; ++i) {
-    JfrStackTrace* stacktrace = _table[i];
+    JfrStackTrace* stacktrace = repo._table[i];
     while (stacktrace != NULL) {
       JfrStackTrace* next = const_cast<JfrStackTrace*>(stacktrace->next());
       delete stacktrace;
       stacktrace = next;
     }
   }
-  memset(_table, 0, sizeof(_table));
-  const size_t processed = _entries;
-  _entries = 0;
+  memset(repo._table, 0, sizeof(repo._table));
+  const size_t processed = repo._entries;
+  repo._entries = 0;
+  repo._last_entries = 0;
   return processed;
 }
 
@@ -147,20 +168,23 @@ traceid JfrStackTraceRepository::record(Thread* thread, int skip /* 0 */) {
 
 traceid JfrStackTraceRepository::record_for(JavaThread* thread, int skip, JfrStackFrame *frames, u4 max_frames) {
   JfrStackTrace stacktrace(frames, max_frames);
-  return stacktrace.record_safe(thread, skip) ? add(stacktrace) : 0;
+  return stacktrace.record_safe(thread, skip) ? add(instance(), stacktrace) : 0;
 }
-
-traceid JfrStackTraceRepository::add(const JfrStackTrace& stacktrace) {
-  traceid tid = instance().add_trace(stacktrace);
+traceid JfrStackTraceRepository::add(JfrStackTraceRepository& repo, const JfrStackTrace& stacktrace) {
+  traceid tid = repo.add_trace(stacktrace);
   if (tid == 0) {
     stacktrace.resolve_linenos();
-    tid = instance().add_trace(stacktrace);
+    tid = repo.add_trace(stacktrace);
   }
   assert(tid != 0, "invariant");
   return tid;
 }
 
-void JfrStackTraceRepository::record_and_cache(JavaThread* thread, int skip /* 0 */) {
+traceid JfrStackTraceRepository::add(const JfrStackTrace& stacktrace) {
+  return add(instance(), stacktrace);
+}
+
+void JfrStackTraceRepository::record_for_leak_profiler(JavaThread* thread, int skip /* 0 */) {
   assert(thread != NULL, "invariant");
   JfrThreadLocal* const tl = thread->jfr_thread_local();
   assert(tl != NULL, "invariant");
@@ -169,7 +193,7 @@ void JfrStackTraceRepository::record_and_cache(JavaThread* thread, int skip /* 0
   stacktrace.record_safe(thread, skip);
   const unsigned int hash = stacktrace.hash();
   if (hash != 0) {
-    tl->set_cached_stack_trace_id(instance().add(stacktrace), hash);
+    tl->set_cached_stack_trace_id(add(leak_profiler_instance(), stacktrace), hash);
   }
 }
 
@@ -196,9 +220,9 @@ traceid JfrStackTraceRepository::add_trace(const JfrStackTrace& stacktrace) {
 }
 
 // invariant is that the entry to be resolved actually exists in the table
-const JfrStackTrace* JfrStackTraceRepository::lookup(unsigned int hash, traceid id) const {
+const JfrStackTrace* JfrStackTraceRepository::lookup_for_leak_profiler(unsigned int hash, traceid id) {
   const size_t index = (hash % TABLE_SIZE);
-  const JfrStackTrace* trace = _table[index];
+  const JfrStackTrace* trace = leak_profiler_instance()._table[index];
   while (trace != NULL && trace->id() != id) {
     trace = trace->next();
   }
@@ -206,4 +230,13 @@ const JfrStackTrace* JfrStackTraceRepository::lookup(unsigned int hash, traceid 
   assert(trace->hash() == hash, "invariant");
   assert(trace->id() == id, "invariant");
   return trace;
+}
+
+void JfrStackTraceRepository::clear_leak_profiler() {
+  clear(leak_profiler_instance());
+}
+
+size_t JfrStackTraceRepository::clear() {
+  clear_leak_profiler();
+  return clear(instance());
 }

--- a/src/hotspot/share/jfr/recorder/stacktrace/jfrStackTraceRepository.hpp
+++ b/src/hotspot/share/jfr/recorder/stacktrace/jfrStackTraceRepository.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,13 +39,14 @@ class JfrStackTraceRepository : public JfrCHeapObj {
   friend class JfrThreadSampleClosure;
   friend class ObjectSampleCheckpoint;
   friend class ObjectSampler;
+  friend class RecordStackTrace;
   friend class StackTraceBlobInstaller;
   friend class StackTraceRepository;
 
  private:
   static const u4 TABLE_SIZE = 2053;
   JfrStackTrace* _table[TABLE_SIZE];
-  traceid _next_id;
+  u4 _last_entries;
   u4 _entries;
 
   JfrStackTraceRepository();
@@ -55,18 +56,21 @@ class JfrStackTraceRepository : public JfrCHeapObj {
   bool initialize();
 
   bool is_modified() const;
+  static size_t clear();
+  static size_t clear(JfrStackTraceRepository& repo);
   size_t write(JfrChunkWriter& cw, bool clear);
-  size_t clear();
 
-  const JfrStackTrace* lookup(unsigned int hash, traceid id) const;
+  static const JfrStackTrace* lookup_for_leak_profiler(unsigned int hash, traceid id);
+  static void record_for_leak_profiler(JavaThread* thread, int skip = 0);
+  static void clear_leak_profiler();
 
   traceid add_trace(const JfrStackTrace& stacktrace);
+  static traceid add(JfrStackTraceRepository& repo, const JfrStackTrace& stacktrace);
   static traceid add(const JfrStackTrace& stacktrace);
   traceid record_for(JavaThread* thread, int skip, JfrStackFrame* frames, u4 max_frames);
 
  public:
   static traceid record(Thread* thread, int skip = 0);
-  static void record_and_cache(JavaThread* thread, int skip = 0);
 };
 
 #endif // SHARE_JFR_RECORDER_STACKTRACE_JFRSTACKTRACEREPOSITORY_HPP

--- a/src/hotspot/share/jfr/support/jfrAllocationTracer.cpp
+++ b/src/hotspot/share/jfr/support/jfrAllocationTracer.cpp
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+* Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
 * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 *
 * This code is free software; you can redistribute it and/or modify it
@@ -26,20 +26,11 @@
 #include "jfr/leakprofiler/leakProfiler.hpp"
 #include "jfr/support/jfrAllocationTracer.hpp"
 #include "jfr/support/jfrObjectAllocationSample.hpp"
-#include "jfr/support/jfrThreadLocal.hpp"
 #include "runtime/thread.hpp"
 
-JfrAllocationTracer::JfrAllocationTracer(const Klass* klass, HeapWord* obj, size_t alloc_size, bool outside_tlab, Thread* thread) : _tl(NULL) {
+JfrAllocationTracer::JfrAllocationTracer(const Klass* klass, HeapWord* obj, size_t alloc_size, bool outside_tlab, Thread* thread) {
   if (LeakProfiler::is_running()) {
-    _tl = thread->jfr_thread_local();
     LeakProfiler::sample(obj, alloc_size, thread->as_Java_thread());
   }
-  // Let this happen after LeakProfiler::sample, to possibly reuse a cached stacktrace.
   JfrObjectAllocationSample::send_event(klass, alloc_size, outside_tlab, thread);
-}
-
-JfrAllocationTracer::~JfrAllocationTracer() {
-  if (_tl != NULL) {
-    _tl->clear_cached_stack_trace();
-  }
 }

--- a/src/hotspot/share/jfr/support/jfrAllocationTracer.hpp
+++ b/src/hotspot/share/jfr/support/jfrAllocationTracer.hpp
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+* Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
 * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 *
 * This code is free software; you can redistribute it and/or modify it
@@ -28,15 +28,11 @@
 #include "memory/allocation.hpp"
 
 class Klass;
-class JfrThreadLocal;
 class Thread;
 
 class JfrAllocationTracer : public StackObj {
- private:
-  JfrThreadLocal* _tl;
  public:
   JfrAllocationTracer(const Klass* klass, HeapWord* obj, size_t alloc_size, bool outside_tlab, Thread* thread);
-  ~JfrAllocationTracer();
 };
 
 #endif // SHARE_JFR_SUPPORT_JFRALLOCATIONTRACER_HPP


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8258414](https://bugs.openjdk.java.net/browse/JDK-8258414): OldObjectSample events too expensive


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk16u pull/107/head:pull/107` \
`$ git checkout pull/107`

Update a local copy of the PR: \
`$ git checkout pull/107` \
`$ git pull https://git.openjdk.java.net/jdk16u pull/107/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 107`

View PR using the GUI difftool: \
`$ git pr show -t 107`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk16u/pull/107.diff">https://git.openjdk.java.net/jdk16u/pull/107.diff</a>

</details>
