### PR TITLE
8266288: assert root method not found in witnessed_reabstraction_in_supers is too strong

### DIFF
--- a/src/hotspot/share/code/dependencies.cpp
+++ b/src/hotspot/share/code/dependencies.cpp
@@ -1534,7 +1534,7 @@ bool ClassHierarchyWalker::witnessed_reabstraction_in_supers(Klass* k) {
           return false;
         }
       }
-      assert(false, "root method not found");
+      // Miranda.
       return true;
     }
     return false;


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8266288](https://bugs.openjdk.java.net/browse/JDK-8266288): assert root method not found in witnessed_reabstraction_in_supers is too strong


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk16u pull/112/head:pull/112` \
`$ git checkout pull/112`

Update a local copy of the PR: \
`$ git checkout pull/112` \
`$ git pull https://git.openjdk.java.net/jdk16u pull/112/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 112`

View PR using the GUI difftool: \
`$ git pr show -t 112`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk16u/pull/112.diff">https://git.openjdk.java.net/jdk16u/pull/112.diff</a>

</details>
