### PR TITLE
8265666: Enable AIX build platform to make external debug symbols

### DIFF
--- a/make/autoconf/jdk-options.m4
+++ b/make/autoconf/jdk-options.m4
@@ -240,11 +240,7 @@ AC_DEFUN_ONCE([JDKOPT_SETUP_DEBUG_SYMBOLS],
       [AS_HELP_STRING([--with-native-debug-symbols],
       [set the native debug symbol configuration (none, internal, external, zipped) @<:@varying@:>@])],
       [
-        if test "x$OPENJDK_TARGET_OS" = xaix; then
-          if test "x$withval" = xexternal || test "x$withval" = xzipped; then
-            AC_MSG_ERROR([AIX only supports the parameters 'none' and 'internal' for --with-native-debug-symbols])
-          fi
-        elif test "x$OPENJDK_TARGET_OS" = xwindows; then
+        if test "x$OPENJDK_TARGET_OS" = xwindows; then
           if test "x$withval" = xinternal; then
             AC_MSG_ERROR([Windows does not support the parameter 'internal' for --with-native-debug-symbols])
           fi
@@ -254,12 +250,7 @@ AC_DEFUN_ONCE([JDKOPT_SETUP_DEBUG_SYMBOLS],
         if test "x$STATIC_BUILD" = xtrue; then
           with_native_debug_symbols="none"
         else
-          if test "x$OPENJDK_TARGET_OS" = xaix; then
-            # AIX doesn't support 'external' so use 'internal' as default
-            with_native_debug_symbols="internal"
-          else
-            with_native_debug_symbols="external"
-          fi
+          with_native_debug_symbols="external"
         fi
       ])
   AC_MSG_RESULT([$with_native_debug_symbols])

--- a/make/common/NativeCompilation.gmk
+++ b/make/common/NativeCompilation.gmk
@@ -974,6 +974,13 @@ define SetupNativeCompilationBody
               $(CD) $$($1_SYMBOLS_DIR) && \
                   $$($1_OBJCOPY) --add-gnu-debuglink=$$($1_DEBUGINFO_FILES) $$($1_TARGET)
 
+        else ifeq ($(call isTargetOs, aix), true)
+          # AIX does not provide the equivalent of OBJCOPY to extract debug symbols,
+          # so we copy the compiled object with symbols to the .debuginfo file, which
+          # happens prior to the STRIP_CMD on the original target object file.
+          $1_DEBUGINFO_FILES := $$($1_SYMBOLS_DIR)/$$($1_NOSUFFIX).debuginfo
+          $1_CREATE_DEBUGINFO_CMDS := $(CP) $$($1_TARGET) $$($1_DEBUGINFO_FILES)
+
         else ifeq ($(call isTargetOs, macosx), true)
           $1_DEBUGINFO_FILES := \
               $$($1_SYMBOLS_DIR)/$$($1_BASENAME).dSYM/Contents/Info.plist \


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8265666](https://bugs.openjdk.java.net/browse/JDK-8265666): Enable AIX build platform to make external debug symbols


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk16u pull/113/head:pull/113` \
`$ git checkout pull/113`

Update a local copy of the PR: \
`$ git checkout pull/113` \
`$ git pull https://git.openjdk.java.net/jdk16u pull/113/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 113`

View PR using the GUI difftool: \
`$ git pr show -t 113`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk16u/pull/113.diff">https://git.openjdk.java.net/jdk16u/pull/113.diff</a>

</details>
