### PR TITLE
8260308: Update LogCompilation junit to 4.13.1

### DIFF
--- a/src/utils/LogCompilation/pom.xml
+++ b/src/utils/LogCompilation/pom.xml
@@ -42,7 +42,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.8.2</version>
+      <version>4.13.1</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
Hi all,

    this pull request contains a backport of commit ef247ab2 from the openjdk/jdk repository.

    The commit being backported was authored by Dan Lutker on 25 Jan 2021 and was reviewed by Eric Caspole and Igor Ignatyev.

    Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8260308](https://bugs.openjdk.java.net/browse/JDK-8260308): Update LogCompilation junit to 4.13.1


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk16u pull/116/head:pull/116` \
`$ git checkout pull/116`

Update a local copy of the PR: \
`$ git checkout pull/116` \
`$ git pull https://git.openjdk.java.net/jdk16u pull/116/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 116`

View PR using the GUI difftool: \
`$ git pr show -t 116`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk16u/pull/116.diff">https://git.openjdk.java.net/jdk16u/pull/116.diff</a>

</details>
