### PR TITLE
8267100: [BACKOUT] JDK-8196415 Disable SHA-1 Signed JARs

### DIFF
--- a/src/java.base/share/conf/security/java.security
+++ b/src/java.base/share/conf/security/java.security
@@ -633,8 +633,7 @@ sun.security.krb5.maxReferrals=5
 #
 #
 jdk.certpath.disabledAlgorithms=MD2, MD5, SHA1 jdkCA & usage TLSServer, \
-    RSA keySize < 1024, DSA keySize < 1024, EC keySize < 224, \
-    SHA1 jdkCA & usage SignedJAR & denyAfter 2019-01-01
+    RSA keySize < 1024, DSA keySize < 1024, EC keySize < 224
 
 #
 # Legacy algorithms for certification path (CertPath) processing and
@@ -698,7 +697,7 @@ jdk.security.legacyAlgorithms=SHA1, \
 # See "jdk.certpath.disabledAlgorithms" for syntax descriptions.
 #
 jdk.jar.disabledAlgorithms=MD2, MD5, RSA keySize < 1024, \
-      DSA keySize < 1024, SHA1 jdkCA & denyAfter 2019-01-01
+      DSA keySize < 1024
 
 #
 # Algorithm restrictions for Secure Socket Layer/Transport Layer Security


### PR DESCRIPTION
Performance issues reported after changes from https://bugs.openjdk.java.net/browse/JDK-8196415

Request to back out from July release and work a better solution for later update release.
Reviewer request: @seanjmullan

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267100](https://bugs.openjdk.java.net/browse/JDK-8267100): [BACKOUT] JDK-8196415 Disable SHA-1 Signed JARs


### Reviewers
 * [Sean Mullan](https://openjdk.java.net/census#mullan) (@seanjmullan - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk16u pull/117/head:pull/117` \
`$ git checkout pull/117`

Update a local copy of the PR: \
`$ git checkout pull/117` \
`$ git pull https://git.openjdk.java.net/jdk16u pull/117/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 117`

View PR using the GUI difftool: \
`$ git pr show -t 117`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk16u/pull/117.diff">https://git.openjdk.java.net/jdk16u/pull/117.diff</a>

</details>
