### PR TITLE
8267345: VM crashes during dumping classlist with -Xshare:dump option

### DIFF
--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -4240,7 +4240,8 @@ void InstanceKlass::log_to_classlist(const ClassFileStream* stream) const {
         // For the boot and platform class loaders, skip classes that are not found in the
         // java runtime image, such as those found in the --patch-module entries.
         // These classes can't be loaded from the archive during runtime.
-        if (!stream->from_boot_loader_modules_image() && strncmp(stream->source(), "jrt:", 4) != 0) {
+        if (!stream->from_boot_loader_modules_image() &&
+            (stream->source() == NULL || strncmp(stream->source(), "jrt:", 4) != 0)) {
           skip = true;
         }
 

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -4255,7 +4255,8 @@ void InstanceKlass::log_to_classlist(const ClassFileStream* stream) const {
     ResourceMark rm;
     if (skip) {
       tty->print_cr("skip writing class %s from source %s to classlist file",
-                    name()->as_C_string(), stream->source());
+                    name()->as_C_string(),
+                    stream->source() != NULL ?  stream->source() : "(null)");
     } else {
       ClassListWriter w;
       w.stream()->print_cr("%s", name()->as_C_string());


### PR DESCRIPTION
Hi, Please review
  The problem is caused by JDK-8247536: Support for pre-generated java.lang.invoke classes in CDS static archive
   Usually the dump with an appointed class list file, -XX:SharedClassListFile=<classlist>, the 'classlist' is collected by pre-run the application with -XX:DumpLoadedClassList, so it is rare case using -Xshare:dump and -XX:DumpLoadedClassList together, though we can do that.
   It is reproducible by run
   java -Xshare:dump -XX:DumpLoadedClassList=<any valid file name>
   The problem happened when regenerating lambda form invoker's holder classes, with which the re-generated class stream without a source associated (class is generated on fly).  Referencing to NULL source failed. Fix checks if source is valid.

Tests: tier1,tier2,tier3,tier4

Thanks
Yumin

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267345](https://bugs.openjdk.java.net/browse/JDK-8267345): VM crashes during dumping classlist with -Xshare:dump option


### Reviewers
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)
 * [Calvin Cheung](https://openjdk.java.net/census#ccheung) (@calvinccheung - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk16u pull/119/head:pull/119` \
`$ git checkout pull/119`

Update a local copy of the PR: \
`$ git checkout pull/119` \
`$ git pull https://git.openjdk.java.net/jdk16u pull/119/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 119`

View PR using the GUI difftool: \
`$ git pr show -t 119`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk16u/pull/119.diff">https://git.openjdk.java.net/jdk16u/pull/119.diff</a>

</details>
