### PR TITLE
8266802: Shenandoah: Round up region size to page size unconditionally

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -151,7 +151,9 @@ jint ShenandoahHeap::initialize() {
   Universe::check_alignment(init_byte_size, reg_size_bytes, "Shenandoah heap");
 
   _num_regions = ShenandoahHeapRegion::region_count();
-  assert(_num_regions == (max_byte_size / reg_size_bytes), "Must match");
+  assert(_num_regions == (max_byte_size / reg_size_bytes),
+         "Regions should cover entire heap exactly: " SIZE_FORMAT " != " SIZE_FORMAT "/" SIZE_FORMAT,
+         _num_regions, max_byte_size, reg_size_bytes);
 
   // Now we know the number of regions, initialize the heuristics.
   initialize_heuristics();

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
@@ -541,10 +541,10 @@ void ShenandoahHeapRegion::setup_sizes(size_t max_heap_size) {
   }
 
   // Make sure region size is at least one large page, if enabled.
-  // Otherwise, uncommitting one region may falsely uncommit the adjacent
-  // regions too.
-  // Also see shenandoahArguments.cpp, where it handles UseLargePages.
-  if (UseLargePages && ShenandoahUncommit) {
+  // The heap sizes would be rounded by heap initialization code by
+  // page size, so we need to round up the region size too, to cover
+  // the heap exactly.
+  if (UseLargePages) {
     region_size = MAX2(region_size, os::large_page_size());
   }
 

--- a/test/hotspot/jtreg/gc/shenandoah/options/TestLargePages.java
+++ b/test/hotspot/jtreg/gc/shenandoah/options/TestLargePages.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2021, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test id=default
+ * @requires vm.gc.Shenandoah
+ *
+ * @run main/othervm -XX:+UseShenandoahGC -Xms128m -Xmx128m TestLargePages
+ * @run main/othervm -XX:+UseShenandoahGC          -Xmx128m TestLargePages
+ * @run main/othervm -XX:+UseShenandoahGC -Xms128m          TestLargePages
+ *
+ * @run main/othervm -XX:+UseShenandoahGC -Xms131m -Xmx131m TestLargePages
+ * @run main/othervm -XX:+UseShenandoahGC          -Xmx131m TestLargePages
+ * @run main/othervm -XX:+UseShenandoahGC -Xms131m          TestLargePages
+ */
+
+/*
+ * @test id=lp
+ * @requires vm.gc.Shenandoah
+ *
+ * @run main/othervm -XX:+UseShenandoahGC -XX:+UseLargePages -Xms128m -Xmx128m TestLargePages
+ * @run main/othervm -XX:+UseShenandoahGC -XX:+UseLargePages          -Xmx128m TestLargePages
+ * @run main/othervm -XX:+UseShenandoahGC -XX:+UseLargePages -Xms128m          TestLargePages
+ *
+ * @run main/othervm -XX:+UseShenandoahGC -XX:+UseLargePages -Xms131m -Xmx131m TestLargePages
+ * @run main/othervm -XX:+UseShenandoahGC -XX:+UseLargePages          -Xmx131m TestLargePages
+ * @run main/othervm -XX:+UseShenandoahGC -XX:+UseLargePages -Xms131m          TestLargePages
+ */
+
+/*
+ * @test id=thp
+ * @requires vm.gc.Shenandoah
+ * @requires os.family == "linux"
+ *
+ * @run main/othervm -XX:+UseShenandoahGC -XX:+UseTransparentHugePages -Xms128m -Xmx128m TestLargePages
+ * @run main/othervm -XX:+UseShenandoahGC -XX:+UseTransparentHugePages          -Xmx128m TestLargePages
+ * @run main/othervm -XX:+UseShenandoahGC -XX:+UseTransparentHugePages -Xms128m          TestLargePages
+ *
+ * @run main/othervm -XX:+UseShenandoahGC -XX:+UseTransparentHugePages -Xms131m -Xmx131m TestLargePages
+ * @run main/othervm -XX:+UseShenandoahGC -XX:+UseTransparentHugePages          -Xmx131m TestLargePages
+ * @run main/othervm -XX:+UseShenandoahGC -XX:+UseTransparentHugePages -Xms131m          TestLargePages
+ */
+
+public class TestLargePages {
+    public static void main(String[] args) {
+        // Everything is checked on initialization
+    }
+}


### PR DESCRIPTION
I would like to backport this patch to 16u.

Without this patch, Shenandoah may not create enough regions to cover whole heap, that results some of heap memory never used.

The original patch applies cleanly to 16u and passed new test in patch.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8266802](https://bugs.openjdk.java.net/browse/JDK-8266802): Shenandoah: Round up region size to page size unconditionally


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk16u pull/120/head:pull/120` \
`$ git checkout pull/120`

Update a local copy of the PR: \
`$ git checkout pull/120` \
`$ git pull https://git.openjdk.java.net/jdk16u pull/120/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 120`

View PR using the GUI difftool: \
`$ git pr show -t 120`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk16u/pull/120.diff">https://git.openjdk.java.net/jdk16u/pull/120.diff</a>

</details>
