### PR TITLE
8267773: PhaseStringOpts::int_stringSize doesn't handle min_jint correctly

### DIFF
--- a/src/hotspot/share/opto/stringopts.cpp
+++ b/src/hotspot/share/opto/stringopts.cpp
@@ -1149,6 +1149,11 @@ Node* PhaseStringOpts::int_stringSize(GraphKit& kit, Node* arg) {
     int arg_val = arg->get_int();
     int count = 1;
     if (arg_val < 0) {
+      // Special case for min_jint - it can't be negated.
+      if (arg_val == min_jint) {
+        return __ intcon(11);
+      }
+
       arg_val = -arg_val;
       count++;
     }

--- a/test/jdk/java/lang/String/concat/IntegerMinValue.java
+++ b/test/jdk/java/lang/String/concat/IntegerMinValue.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2021, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8267773
+ * @summary Test
+ *
+ * @compile IntegerMinValue.java
+ * @run main/othervm -Xverify:all -Xbatch IntegerMinValue
+ *
+ * @compile -XDstringConcat=inline IntegerMinValue.java
+ * @run main/othervm -Xverify:all -Xbatch IntegerMinValue
+ *
+ * @compile -XDstringConcat=indy IntegerMinValue.java
+ * @run main/othervm -Xverify:all -Xbatch IntegerMinValue
+ *
+ * @compile -XDstringConcat=indyWithConstants IntegerMinValue.java
+ * @run main/othervm -Xverify:all -Xbatch IntegerMinValue
+*/
+
+public class IntegerMinValue {
+
+    public void test() {
+        int i = Integer.MIN_VALUE;
+        String s = "" + i;
+        if (!"-2147483648".equals(s)) {
+           throw new IllegalStateException("Failed: " + s);
+        }
+        System.out.println(s);
+    }
+
+    public static void main(String[] strArr) {
+        IntegerMinValue t = new IntegerMinValue();
+        for (int i = 0; i < 100_000; i++ ) {
+            t.test();
+        }
+    }
+
+}


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit d47a77d2 from the openjdk/jdk repository.

The commit being backported was authored by Nils Eliasson on 2 Jun 2021 and was reviewed by Roland Westrelin.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8267773](https://bugs.openjdk.java.net/browse/JDK-8267773): PhaseStringOpts::int_stringSize doesn't handle min_jint correctly


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk16u pull/127/head:pull/127` \
`$ git checkout pull/127`

Update a local copy of the PR: \
`$ git checkout pull/127` \
`$ git pull https://git.openjdk.java.net/jdk16u pull/127/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 127`

View PR using the GUI difftool: \
`$ git pr show -t 127`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk16u/pull/127.diff">https://git.openjdk.java.net/jdk16u/pull/127.diff</a>

</details>
